### PR TITLE
Add 96Boards HiKey960 board support

### DIFF
--- a/driver/Makefile
+++ b/driver/Makefile
@@ -15,7 +15,7 @@ INC_DIR+=-I$(shell pwd)/../core/include
 INC_DIR+=-I$(shell pwd)/../operator/include 
 INC_DIR+=-I$(shell pwd)/../executor/include 
 
-MODULE_DIR=rk3399  plugin
+MODULE_DIR=rk3399 hikey960 plugin 
 MODULE_NAME=libdriver.so
 
 CXXFLAGS+=

--- a/driver/hikey960/Makefile
+++ b/driver/hikey960/Makefile
@@ -1,0 +1,7 @@
+obj-y+=hikey960_driver.o
+obj-y+=hikey960_executor.o
+
+hikey960_driver_CXXFLAGS+=-I.
+hikey960_executor_CXXFLAGS+=-I.
+
+

--- a/driver/hikey960/hikey960_driver.cpp
+++ b/driver/hikey960/hikey960_driver.cpp
@@ -1,0 +1,220 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * License); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * AS IS BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+/*
+ * Copyright (c) 2018, Open AI Lab
+ * Author: haitao@openailab.com
+ * Copyright (c) 2018, Linaro Ltd
+ * Author: Manivannan Sadhasivam <manivannan.sadhasivam@linaro.org>
+ */
+
+#include <sched.h>
+#include <chrono>
+#include <functional>
+
+#include "tensor_mem.hpp"
+#include "hikey960_driver.hpp"
+#include "hikey960_executor.hpp"
+#include "logger.hpp"
+
+
+namespace TEngine {
+
+
+HIKEY960Driver::HIKEY960Driver(void)
+{
+	SetName("HIKEY960");
+
+	id_table_.push_back("cpu.hikey960.a53.all");
+	id_table_.push_back("cpu.hikey960.a73.all");
+	id_table_.push_back("cpu.hikey960.cpu.all");
+	id_table_.push_back("cpu.hikey960.a73.0");
+	id_table_.push_back("cpu.hikey960.a53.2");
+
+}
+
+
+int HIKEY960Driver::ProbeDevice(void) 
+{
+	int number=0;
+
+	for(unsigned int i=0; i<id_table_.size();i++)
+	{
+		const dev_id_t& dev_id=id_table_[i];
+		if(ProbeDevice(dev_id))
+			number++;
+	}
+
+	return number;
+}
+
+bool HIKEY960Driver::ProbeDevice(const dev_id_t& dev_id)
+{
+	if(dev_id==std::string("cpu.hikey960.a73.all"))
+	{
+		CPUDevice * dev=new A73Device();
+
+		dev->SetName(dev_id);
+
+		InitializeDevice(dev);
+
+		device_table_[dev->GetName()]=dev;
+
+		return true;
+	}
+        else
+        if(dev_id == std::string("cpu.hikey960.a53.all"))
+        {
+		CPUDevice * dev=new HKA53Device();
+
+		dev->SetName(dev_id);
+
+		InitializeDevice(dev);
+
+		device_table_[dev->GetName()]=dev;
+
+                return true;
+
+        }
+        else if(dev_id == std::string("cpu.hikey960.cpu.all"))
+        {
+                CPUDevice * dev=new HIKEY960Device();
+
+                dev->SetName(dev_id);
+
+                InitializeDevice(dev);
+
+                device_table_[dev->GetName()]=dev;
+
+                return true;
+        }
+        else if (dev_id == "cpu.hikey960.a73.0")
+        {
+               CPUDevice * dev=new  SingleA73Device();
+               dev->SetName(dev_id);
+               InitializeDevice(dev);
+               device_table_[dev->GetName()]=dev;
+               return true;
+        }
+        else if(dev_id == "cpu.hikey960.a53.2")
+        {
+               CPUDevice * dev=new  HKSingleA53Device();
+               dev->SetName(dev_id);
+               InitializeDevice(dev);
+               device_table_[dev->GetName()]=dev;
+               return true;
+        }
+	return false;
+}
+
+int HIKEY960Driver::DestroyDevice(void)
+{
+	auto ir=device_table_.begin();
+	auto end=device_table_.end();
+
+	int count=0;
+
+	while(ir!=end)
+	{
+		if(DestroyDevice(ir->second))
+			count++;
+		else
+			ir++;
+	}
+
+	return count;
+}
+
+bool HIKEY960Driver::DestroyDevice(Device * device) 
+{
+	CPUDevice * cpu_dev=reinterpret_cast<CPUDevice *>(device);
+
+	if(GetDeviceStatus(cpu_dev)!=kDevStopped)
+		return false;
+
+	ReleaseDevice(cpu_dev);
+
+	device_table_.erase(cpu_dev->GetName());
+
+	delete cpu_dev;
+
+	return true;
+}
+
+int HIKEY960Driver::GetDeviceNum(void) 
+{
+	return device_table_.size();
+}
+
+Device * HIKEY960Driver::GetDevice(int idx) 
+{
+	auto ir=device_table_.begin();
+	auto end=device_table_.end();
+
+	int i;
+
+	for(i=0;i<idx && ir!=end;i++,ir++);
+
+	if(ir==end)
+		return nullptr;
+
+	return ir->second;
+}
+
+Device * HIKEY960Driver::GetDevice(const std::string& name) 
+{
+	if(device_table_.count(name)==0)
+		return nullptr;
+	return device_table_[name];
+}
+
+
+
+int HIKEY960Driver::GetDevIDTableSize()
+{	
+     return id_table_.size();
+}
+
+const dev_id_t& HIKEY960Driver::GetDevIDbyIdx(int idx)
+{
+	return id_table_[idx];
+}
+
+
+bool HIKEY960Driver::GetWorkload(Device * dev, DevWorkload& load)
+{
+    //TO BE IMPLEMENTED
+    return false;
+}
+
+bool HIKEY960Driver::GetPerf(Device * dev, Subgraph * graph,int policy,GraphPerf& perf)
+{
+    //TO BE IMPLEMENTED
+   return false;
+}
+
+float HIKEY960Driver::GetFops(Device * dev, Subgraph * graph) 
+{
+    //TO BE IMPLEMENTED
+    return false;
+}
+
+
+} //namespace TEngine
+

--- a/driver/hikey960/hikey960_executor.cpp
+++ b/driver/hikey960/hikey960_executor.cpp
@@ -1,0 +1,142 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * License); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * AS IS BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+/*
+ * Copyright (c) 2018, Open AI Lab
+ * Author: haitao@openailab.com
+ * Copyright (c) 2018, Linaro Ltd
+ * Author: Manivannan Sadhasivam <manivannan.sadhasivam@linaro.org>
+ */
+#include "hikey960_driver.hpp"
+#include "hikey960_executor.hpp"
+
+
+namespace TEngine {
+
+void HIKEY960Executor::DevGetWorkload(DevWorkload& load)
+{
+	//TO BE IMPLEMENTED;
+}
+
+
+bool HIKEY960Executor::DevGetPerf(Subgraph * graph,int policy,GraphPerf& perf)
+{
+	//TO BE IMPLEMENTED;
+	return false;
+}
+
+float HIKEY960Executor::DevGetFops(Subgraph * graph)
+{
+	//TO BE IMPLEMENTED;
+	return 0;
+}
+
+void * HIKEY960Executor::DevCreateGraphHandle(Subgraph * graph)
+{
+	return backend_dev_->CreateGraphHandle(graph);
+
+}
+
+bool HIKEY960Executor::DevOptimzeGraph(void * graph_handle)
+{
+	return backend_dev_->OptimizeGraph(graph_handle);
+}
+
+bool HIKEY960Executor::DevPrerun(void * graph_handle)
+{
+	return backend_dev_->Prerun(graph_handle);
+}
+
+bool HIKEY960Executor::DevRun(void * graph_handle)
+{
+        auto f=std::bind(&HIKEY960Executor::OnSubgraphDone,this,std::placeholders::_1,
+				std::placeholders::_2);
+
+        backend_dev_->SetGraphDoneHook(graph_handle,dev_graph_cb_t(f));
+
+	return backend_dev_->Run(graph_handle);
+}
+
+bool HIKEY960Executor::DevSyncRun(void * graph_handle)
+{
+	return backend_dev_->SyncRun(graph_handle);
+}
+
+bool HIKEY960Executor::DevPostrun(void * graph_handle)
+{
+	return backend_dev_->Postrun(graph_handle);
+}
+
+bool HIKEY960Executor::DevReleaseGraphHandle(void * graph_handle)
+{
+	return backend_dev_->ReleaseGraphHandle(graph_handle);
+}
+
+
+const dev_id_t& HIKEY960Executor::DevGetID(void)
+{
+	return backend_dev_->GetDeviceID();
+}
+
+const dev_type_t & HIKEY960Executor::DevGetType(void)
+{
+	return backend_dev_->GetDeviceType();
+}
+
+dev_status_t HIKEY960Executor::DevGetStatus(void)
+{
+	return backend_dev_->GetDeviceStatus();
+}
+
+bool HIKEY960Executor::Init(void)
+{
+	return true;
+}
+
+bool HIKEY960Executor::Release(void)
+{
+	return true;
+}
+
+void  HIKEY960Executor::UnbindDevice(void)
+{
+	backend_dev_=nullptr;
+}
+
+void HIKEY960Executor::BindDevice(Device *  device)
+{
+	CPUDevice * dev=dynamic_cast<CPUDevice *>(device);
+	backend_dev_=dev;
+}
+
+bool HIKEY960Executor::DevStart(void) 
+{
+	return 	backend_dev_->Start();
+}
+
+bool HIKEY960Executor::DevStop(void)
+{
+	return  backend_dev_->Stop();
+}
+
+
+} //namespace TEngine
+
+
+

--- a/driver/include/hikey960_driver.hpp
+++ b/driver/include/hikey960_driver.hpp
@@ -1,0 +1,237 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * License); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * AS IS BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+/*
+ * Copyright (c) 2018, Open AI Lab
+ * Author: haitao@openailab.com
+ * Copyright (c) 2018, Linaro Ltd
+ * Author: Manivannan Sadhasivam <manivannan.sadhasivam@linaro.org>
+ */
+
+#ifndef __HIKEY960_DRIVER_HPP__
+#define __HIKEY960_DRIVER_HPP__
+
+#include <atomic>
+#include <thread>
+#include <queue>
+#include <condition_variable>
+
+#include "device_driver.hpp"
+#include "cpu_driver.hpp"
+
+namespace TEngine {
+
+class HIKEY960Executor;
+
+
+class HIKEY960Driver : public CPUDriver {
+public:
+	
+	HIKEY960Driver();
+	
+	int ProbeDevice(void) override;
+	bool ProbeDevice(const dev_id_t& dev_id) override;
+	
+	int DestroyDevice(void) override;
+	bool DestroyDevice(Device * device) override;
+
+	int GetDeviceNum(void) override;
+	Device * GetDevice(int idx) override;
+        Device * GetDevice(const std::string& name) override;
+
+       bool GetWorkload(Device * dev, DevWorkload& load) override;
+       bool GetPerf(Device * dev, Subgraph * graph,int policy,GraphPerf& perf) override;
+       float GetFops(Device * dev, Subgraph * graph) override;
+
+	int GetDevIDTableSize();
+	const dev_id_t& GetDevIDbyIdx(int idx);
+
+protected:
+
+	std::vector<dev_id_t> id_table_;
+        std::unordered_map<std::string, Device *> device_table_;	
+};
+
+
+
+class HIKEY960Runner: public CPURunner {
+public: 
+      HIKEY960Runner(void) {
+         if(!GetPredefinedSoc("HIKEY960",soc_info))
+         {
+            throw(std::runtime_error("SoC HIKEY960 is not defined yet"));
+         }
+      }
+
+};
+
+
+class A73Device : public CPUDevice {
+public:
+	A73Device(): CPUDevice("cpu.hikey960.a73.all")
+	{
+	      
+	      for(unsigned int i=4;i<8;i++)
+	      {
+          	       CPUCore * cpu= new CPUCore();
+	      		cpu->hw_cpu_id=i;
+			cpu->cpu_type="A73";
+			cpu->dev=static_cast<CPUDevice*>(this);
+			compute_cores.push_back(cpu);
+	      }
+
+
+              master_cpu_idx=1;
+              compute_cores[master_cpu_idx]->master=true;
+
+              HIKEY960Runner * runner=new HIKEY960Runner();
+
+              std::vector<int> real_cpu={4,5,6,7};
+
+              runner->SetWorkingCPU(real_cpu,7);
+
+              backend_runner=runner;
+	}
+       
+};
+
+class HKA53Device: public CPUDevice {
+public:
+	HKA53Device(): CPUDevice("cpu.hikey960.a53.all") 
+	{
+	      for(unsigned int i=0;i<4;i++)
+	      {
+	                CPUCore * cpu=new CPUCore();
+	      		cpu->hw_cpu_id=i;
+			cpu->cpu_type="A53";
+			cpu->dev=static_cast<CPUDevice*>(this);
+			compute_cores.push_back(cpu);
+	      }
+
+              master_cpu_idx=0;
+	      compute_cores[master_cpu_idx]->master=true;
+
+              HIKEY960Runner * runner=new HIKEY960Runner();
+
+              std::vector<int> real_cpu={0,1,2,3};
+
+              runner->SetWorkingCPU(real_cpu,0);
+
+              backend_runner=runner;
+       
+	}
+	
+};
+
+class HIKEY960Device: public CPUDevice {
+public:
+	HIKEY960Device(): CPUDevice("cpu.hikey960.cpu.all") 
+       {
+	      for(unsigned int i=0;i<8;i++)
+	      {
+	              CPUCore * cpu=new CPUCore();
+	     
+	      		cpu->hw_cpu_id=i;
+			cpu->dev=static_cast<CPUDevice*>(this);
+			
+			if(i<4)
+				cpu->cpu_type="A53";
+			else
+				cpu->cpu_type="A73";
+	       
+        	       compute_cores.push_back(cpu);
+	     }
+
+	    compute_cores[4]->master=true;
+            master_cpu_idx=4;
+
+            HIKEY960Runner * runner=new HIKEY960Runner();
+
+            backend_runner=runner;
+
+	}
+
+
+};
+
+class SingleA73Device : public CPUDevice {
+public:
+        SingleA73Device(): CPUDevice("cpu.hikey960.a73.0")
+        {
+
+              for(unsigned int i=4;i<5;i++)
+              {
+                       CPUCore * cpu= new CPUCore();
+                        cpu->hw_cpu_id=i;
+                        cpu->cpu_type="A73";
+                        cpu->dev=static_cast<CPUDevice*>(this);
+                        compute_cores.push_back(cpu);
+              }
+
+
+              master_cpu_idx=0;
+              compute_cores[master_cpu_idx]->master=true;
+
+              HIKEY960Runner * runner=new HIKEY960Runner();
+
+              std::vector<int> real_cpu={4};
+
+              runner->SetWorkingCPU(real_cpu,4);
+
+              backend_runner=runner;
+        }
+
+};
+
+class HKSingleA53Device : public CPUDevice {
+public:
+        HKSingleA53Device(): CPUDevice("cpu.hikey960.a53.2")
+        {
+
+              for(unsigned int i=2;i<3;i++)
+              {
+                       CPUCore * cpu= new CPUCore();
+                        cpu->hw_cpu_id=i;
+                        cpu->cpu_type="A53";
+                        cpu->dev=static_cast<CPUDevice*>(this);
+                        compute_cores.push_back(cpu);
+              }
+
+
+              master_cpu_idx=0;
+              compute_cores[master_cpu_idx]->master=true;
+
+              HIKEY960Runner * runner=new HIKEY960Runner();
+
+              std::vector<int> real_cpu={2};
+
+              runner->SetWorkingCPU(real_cpu,2);
+
+              backend_runner=runner;
+        }
+
+};
+
+
+
+} //namespace TEngine
+
+
+
+#endif

--- a/driver/include/hikey960_executor.hpp
+++ b/driver/include/hikey960_executor.hpp
@@ -1,0 +1,78 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * License); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * AS IS BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+/*
+ * Copyright (c) 2018, Open AI Lab
+ * Author: haitao@openailab.com
+ * Copyright (c) 2018, Linaro Ltd.
+ * Author: Manivannan Sadhasivam <manivannan.sadhasivam@linaro.org>
+ */
+
+#ifndef __HIKEY960_EXECUTOR_HPP__
+#define __HIKEY960_EXECUTOR_HPP__
+
+#include "generic_dev_executor.hpp"
+
+
+namespace TEngine {
+
+class CPUDevice;
+
+class HIKEY960Executor: public GenericDevExecutor {
+
+public:
+
+	HIKEY960Executor(const dev_id_t& dev_id) {dev_id_=dev_id;}
+
+	void DevGetWorkload(DevWorkload& load) override;	
+	bool DevGetPerf(Subgraph * graph,int policy,GraphPerf& perf)override;
+	float DevGetFops(Subgraph * graph) override; 
+	
+	void * DevCreateGraphHandle(Subgraph * graph) override;
+	bool DevOptimzeGraph(void * graph_handle) override;
+	bool DevPrerun(void * graph_handle) override;
+	bool DevRun(void * graph_handle) override;
+	bool DevSyncRun(void * graph_handle) override;
+	bool DevPostrun(void * graph_handle) override;
+	bool DevReleaseGraphHandle(void * graph_handle) override;
+	bool DevStart(void) override;
+	bool DevStop(void) override;
+	
+	const dev_id_t& DevGetID(void) override;
+	const dev_type_t & DevGetType(void) override;
+	
+    	dev_status_t DevGetStatus(void) override;
+		
+	bool Init(void) override;
+        bool Release(void) override;
+
+       void UnbindDevice(void) override;
+       void BindDevice(Device * ) override;
+   
+	void SetDevice(CPUDevice * dev) {backend_dev_=dev;}
+	CPUDevice * GetDevice(void) {return backend_dev_;}
+protected:
+	CPUDevice * backend_dev_;
+	dev_id_t  dev_id_;
+	
+};
+
+} //namespace TEngine
+
+#endif

--- a/driver/plugin/Makefile
+++ b/driver/plugin/Makefile
@@ -1,3 +1,3 @@
 obj-y+=init.o
 
-init_CXXFLAGS+=-I../driver/rk3399
+init_CXXFLAGS+=-I../driver/rk3399 -I../driver/hikey960

--- a/driver/plugin/init.cpp
+++ b/driver/plugin/init.cpp
@@ -27,6 +27,8 @@
 #include "logger.hpp"
 #include "rk3399_driver.hpp"
 #include "rk3399_executor.hpp"
+#include "hikey960_driver.hpp"
+#include "hikey960_executor.hpp"
 
 extern "C" {
     int tengine_plugin_init(void);
@@ -38,7 +40,9 @@ int tengine_plugin_init(void)
 {
 
     RK3399Driver * rk3399=new RK3399Driver();
+    HIKEY960Driver * hikey960=new HIKEY960Driver();
     DriverManager::RegisterDriver(rk3399->GetName(),rk3399);
+    DriverManager::RegisterDriver(hikey960->GetName(),hikey960);
 
     //Executor Factory registration
     auto dev_executor_factory=DevExecutorFactory::GetFactory();
@@ -46,11 +50,20 @@ int tengine_plugin_init(void)
     //for each dev_id in driver rk3399, regiser one executor 
     int n=rk3399->GetDevIDTableSize();
 
-    for(int i=0;i<n;i++)
+    for(int i=0;i<n;i++) {
          dev_executor_factory->
                 RegisterInterface<RK3399Executor,const dev_id_t&>(rk3399->GetDevIDbyIdx(i));
+    }
 
-   std::cout<<"DEV ENGINE PLUGIN INITED\n";
+    //for each dev_id in driver hikey960, regiser one executor 
+    n=hikey960->GetDevIDTableSize();
+    
+    for(int i=0;i<n;i++) {
+         dev_executor_factory->
+                RegisterInterface<HIKEY960Executor,const dev_id_t&>(hikey960->GetDevIDbyIdx(i));
+    }
+   
+    std::cout<<"DEV ENGINE PLUGIN INITED\n";
 
-   return 0;
+    return 0;
 }

--- a/executor/lib/soc_runner.cpp
+++ b/executor/lib/soc_runner.cpp
@@ -436,7 +436,6 @@ void  RegisterDefaultSoc(void)
 {
 	SocInfo soc_info;
 
-
 	soc_info.cpu_number=6;
 	soc_info.soc_name="RK3399";
 	soc_info.master_cpu=4;
@@ -469,6 +468,35 @@ void  RegisterDefaultSoc(void)
 
 	RegisterPredefinedSoc(soc_info.soc_name,soc_info);
 
+	soc_info.cpu_number=8;
+	soc_info.soc_name="HIKEY960";
+	soc_info.master_cpu=4;
+
+	for(int i=0;i<4;i++)
+	{
+		cpu_info.cpu_id=i;
+		cpu_info.cpu_type="A53";
+		cpu_info.cpu_arch="arm64";
+		cpu_info.l1_size=32*1024;
+		cpu_info.l2_slice=256*1024;
+
+		soc_info.cpu_info.push_back(cpu_info);
+		soc_info.cpu_list.push_back(i);
+	}
+
+	for(int i=4;i<8;i++)
+	{
+		cpu_info.cpu_id=i;
+		cpu_info.cpu_type="A73";
+		cpu_info.cpu_arch="arm64";
+		cpu_info.l1_size=32*1024;
+		cpu_info.l2_slice=512*1024;
+
+		soc_info.cpu_info.push_back(cpu_info);
+		soc_info.cpu_list.push_back(i);
+	}
+
+	RegisterPredefinedSoc(soc_info.soc_name,soc_info);
 }
 
 

--- a/executor/operator/arm/batch_norm.cpp
+++ b/executor/operator/arm/batch_norm.cpp
@@ -25,6 +25,7 @@
 #include <functional>
 #include <cstring>
 #include <algorithm>
+#include <cmath>
 
 #include "logger.hpp"
 #include "node_ops.hpp"


### PR DESCRIPTION
This PR adds 96Boards HiKey960 board support to Tengine. HiKey960 is based on HI3660 ARM Aarch64 octa-core processor from HiSilicon which has 4x A53 cores and 4x A73 cores.

More information can be found in 96Boards product page: https://www.96boards.org/product/hikey960/