### PR TITLE
replacing int with float as bias variable type

### DIFF
--- a/executor/operator/common/blas/deconv_2d_blas.cpp
+++ b/executor/operator/common/blas/deconv_2d_blas.cpp
@@ -66,7 +66,7 @@ struct DeconvBlasOps : public NodeOps
         float* out_ptr=output;
         for(int c = 0; c < c_out; ++c)
         {
-            int val=bias[c];
+            float val=bias[c];
             for(int i = 0; i < hw; ++i)
             {
                 *out_ptr += val;


### PR DESCRIPTION
deconvolution was converting bias to int so if it was between 0 and 1 it wasn't used at all