### PR TITLE
adding cmake-build-debug to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@
 *.exe
 tests/data/
 build/
+cmake-build-debug/
 *.log
 *.pb.cc
 *.pb.h


### PR DESCRIPTION
I wasn't sure about the right location of this extra directory in .gitignore
Also it could be in my personal gitignore but maybe it's useful for the others so I wanted to see if you want to merge it.