### PR TITLE
fixing lighten cnn get data validation

### DIFF
--- a/examples/lighten_cnn/lighten_cnn.cpp
+++ b/examples/lighten_cnn/lighten_cnn.cpp
@@ -41,7 +41,7 @@ void get_data(void* buffer, int datasize, const char* fname)
     if (!data_fp) printf("data can not be open\n");
 
     size_t n=fread(buffer, sizeof(float), datasize, data_fp);
-    if(n<0)
+    if (n < datasize)
         printf("data read error\n");
 
     fclose(data_fp);


### PR DESCRIPTION
This comparison was always false which was a problem for Werror flag