### PR TITLE
fix bugs in cpu_prob.

### DIFF
--- a/executor/include/cpu_info.hpp
+++ b/executor/include/cpu_info.hpp
@@ -13,17 +13,15 @@ struct CPUInfo {
 
 	struct cpu_cluster * find_cluster(int cpu_id) const
 	{
-		int start_idx=0;
-		struct cpu_cluster * p_cluster;
-
-		for(int i=0;i<dev.cluster_number;i++)
+	    	struct cpu_cluster * p_cluster;
+		for(int i=0; i<dev.cluster_number;i++)
 		{
-			p_cluster=&dev.cluster[i];
-
-			if(cpu_id>=start_idx && cpu_id<start_idx+p_cluster->cpu_number)
-				return p_cluster;
-
-			start_idx+=p_cluster->cpu_number;
+		    p_cluster = &dev.cluster[i];
+		    //iterate each cpu in this cluster.
+		    for(int j=0; j<p_cluster->cpu_number; j++){
+			if(cpu_id == p_cluster->hw_cpu_id[j])
+			    return p_cluster;
+		    }
 		}
 
 		return NULL;


### PR DESCRIPTION
fix bugs in prob_cpu. Specific modifications are listed below:
(1) use physical cpu id read from /proc/cpuinfo.
(2) distribute each cpu to cpu_cluster based on its 'CPU part' field  in /proc/cpuinfo

I have tested on nvidia jetson tx2 with all cpus(4 arm v8+2 nvidia denver) and arm cpus only.