### PR TITLE
Fix prob cpu

### DIFF
--- a/executor/include/cpu_info.hpp
+++ b/executor/include/cpu_info.hpp
@@ -13,17 +13,15 @@ struct CPUInfo {
 
 	struct cpu_cluster * find_cluster(int cpu_id) const
 	{
-		int start_idx=0;
-		struct cpu_cluster * p_cluster;
-
-		for(int i=0;i<dev.cluster_number;i++)
+	    	struct cpu_cluster * p_cluster;
+		for(int i=0; i<dev.cluster_number;i++)
 		{
-			p_cluster=&dev.cluster[i];
-
-			if(cpu_id>=start_idx && cpu_id<start_idx+p_cluster->cpu_number)
-				return p_cluster;
-
-			start_idx+=p_cluster->cpu_number;
+		    p_cluster = &dev.cluster[i];
+		    //iterate each cpu in this cluster.
+		    for(int j=0; j<p_cluster->cpu_number; j++){
+			if(cpu_id == p_cluster->hw_cpu_id[j])
+			    return p_cluster;
+		    }
 		}
 
 		return NULL;


### PR DESCRIPTION
fix bugs in probing CPU by using a 2-stage method in the cpu cluster distribution, which should work for big.LITLE arm CPUs and heterogeneous SoCs such as nvidia jetson TX2.
We assign a group for each CPU based on its 'CPU part' filed first. Then, CPUs within a group are divided into clusters based on its max_freq. Tests on TX2 with all CPUs(4 arm v8+2 nvidia denver) and arm CPUs only are performed.