### PR TITLE
fix: C++ options only for C++ code

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -78,10 +78,11 @@ add_definitions(-fPIC)
 add_definitions(-g)
 add_definitions(-O3)
 add_definitions(-funroll-loops)
-add_definitions(-Wno-overloaded-virtual)
 add_definitions(-Wno-deprecated-register)
-add_compile_options($<$<COMPILE_LANGUAGE:CXX>:-std=c++11>)
 
+set(CMAKE_CXX_STANDARD 11)
+set(CXX_STANDARD_REQUIRED ON)
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-overloaded-virtual")
 
 include_directories(include)
 


### PR DESCRIPTION
* -Wno-overloaded-virtual works only for C++ and this fails
  because of -Werror
* This also use replace C++11 compile options with more cmake
  idiomatic way.