### PR TITLE
Fix crash issue during serializing onnx model

### DIFF
--- a/core/lib/static_graph.cpp
+++ b/core/lib/static_graph.cpp
@@ -312,6 +312,11 @@ int AddNodeInputTensor(StaticNode* node, StaticTensor* tensor)
 {
     int input_idx = node->input_tensor_list.size();
 
+    if (!tensor){
+         LOG_ERROR() << "Invalid tensor with address: " << tensor << "\n";
+         return input_idx;
+    }
+
     node->input_tensor_list.push_back(tensor->index);
 
     AddTensorConsumer(tensor, node, input_idx);


### PR DESCRIPTION
Tengine may crash during serializing onnx model:
```bash
Using host libthread_db library "/lib/x86_64-linux-gnu/libthread_db.so.1".
Core was generated by `build/tests/bin/test_onnx_sqz'.
Program terminated with signal SIGSEGV, Segmentation fault.
#0  __gnu_cxx::new_allocator<int>::construct<int, int const&> (__p=<optimized out>, this=<optimized out>) at /usr/include/c++/5/ext/new_allocator.h:120
120             { ::new((void *)__p) _Up(std::forward<_Args>(__args)...); }
[Current thread is 1 (Thread 0x7fbd6d38eac0 (LWP 12))]
(gdb) bt
#0  __gnu_cxx::new_allocator<int>::construct<int, int const&> (__p=<optimized out>, this=<optimized out>) at /usr/include/c++/5/ext/new_allocator.h:120
#1  std::allocator_traits<std::allocator<int> >::construct<int, int const&> (__p=<optimized out>, __a=...) at /usr/include/c++/5/bits/alloc_traits.h:530
#2  std::vector<int, std::allocator<int> >::_M_emplace_back_aux<int const&> (this=this@entry=0x192fb38) at /usr/include/c++/5/bits/vector.tcc:416
#3  0x00007fbd6cd585f5 in std::vector<int, std::allocator<int> >::push_back (__x=@0x28: <error reading variable>, this=0x192fb38) at /usr/include/c++/5/bits/stl_vector.h:923
#4  TEngine::AddNodeInputTensor (node=node@entry=0x192fb00, tensor=0x0) at static_graph.cpp:315
#5  0x00007fbd6cef96a7 in TEngine::OnnxSerializer::LoadNode (this=this@entry=0x16d8af0, graph=graph@entry=0x16c24b0, node=node@entry=0x192fb00, onnx_node=...) at onnx_serializer.cpp:227
#6  0x00007fbd6cefa468 in TEngine::OnnxSerializer::LoadGraph (this=this@entry=0x16d8af0, model=..., graph=graph@entry=0x16c24b0) at onnx_serializer.cpp:273
#7  0x00007fbd6cf009d6 in TEngine::OnnxSerializer::LoadModel (this=0x16d8af0, file_list=std::vector of length 1, capacity 1 = {...}, graph=0x16c24b0) at onnx_serializer.cpp:67
#8  0x00007fbd6cd711e3 in real_vload_model(context_t, const char *, const char *, const void *, int, typedef __va_list_tag __va_list_tag *) (exec_context=exec_context@entry=0x16ce5d0, 
    model_name=model_name@entry=0x16c21c0 "0x16ce5d0:./models/sqz.onnx.model", model_format=model_format@entry=0x403b2f "onnx", addr=addr@entry=0x403bd5, mem_size=mem_size@entry=0, 
    argp=argp@entry=0x7fff23341c48) at tengine_c_helper.cpp:168
#9  0x00007fbd6cd719a0 in vload_model(context_t, const char *, const char *, const void *, int, typedef __va_list_tag __va_list_tag *) (exec_context=0x16ce5d0, 
    model_name=0x16c21c0 "0x16ce5d0:./models/sqz.onnx.model", model_format=0x403b2f "onnx", addr=0x403bd5, mem_size=0, argp=0x7fff23341c48) at tengine_c_helper.cpp:222
#10 0x00007fbd6cd5fe85 in create_graph (context=context@entry=0x0, model_format=model_format@entry=0x403b2f "onnx", fname=0x403bd5 "./models/sqz.onnx.model") at tengine_c_api.cpp:155
#11 0x0000000000402331 in main (argc=<optimized out>, argv=<optimized out>) at test_onnx_sqz.cpp:69
```
This is because the tensor returned by FindTensor API may be null:
```cpp
StaticTensor* tensor = FindTensor(graph, input_name);
```