### PR TITLE
fix flatten.cpp and CMakeLists bug

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -197,13 +197,13 @@ ADD_LIBRARY(tengine SHARED ${TENGINE_LIB_SRCS} ${TENGINE_SIGN_SRCS})
 
 #executor
 ADD_DEPENDENCIES(hclcpu KERNEL_ASM_TARGET)
-TARGET_LINK_LIBRARIES(hclcpu tengine)
+TARGET_LINK_LIBRARIES(tengine hclcpu)
 
 #target_compile_definitions(operator,"--allow-shlib-undefined")
 
 if(PROTOBUF_DIR)
     if(ANDROID AND ("${CMAKE_SYSTEM_PROCESSOR}" STREQUAL "armv7-a"))
-         set(PROTOBUF_LIB ${PROTOBUF_DIR}/arm32_lib/libprotobuf.so)
+       set(PROTOBUF_LIB ${PROTOBUF_DIR}/arm32_lib/libprotobuf.so)
     endif()
     if(ANDROID AND ("${CMAKE_SYSTEM_PROCESSOR}" STREQUAL "aarch64"))
        set(PROTOBUF_LIB ${PROTOBUF_DIR}/arm64_lib/libprotobuf.so)

--- a/operator/operator/flatten.cpp
+++ b/operator/operator/flatten.cpp
@@ -30,9 +30,9 @@ bool Flatten::InferShape(const std::vector<TEngine::TShape>& ishape, std::vector
     const TShape& input = ishape[0];
 
     const std::vector<int>& in_dim = input.GetDim();
-
+    const int size = in_dim.size();
     int new_channel = 1;
-    for(int i = param_.axis; i <= param_.end_axis; i++)
+    for(int i = param_.axis; i < size; i++)
     {
         new_channel *= in_dim[i];
     }


### PR DESCRIPTION
1、libtengine.so is dependent on libhclcpu.so, although it may not cause an error.
2、for flatten layer，if the dim of the input is not 4, the shape of the output may be wrong.