### PR TITLE
[CORE] Delete redundant include in Makefile

### DIFF
--- a/core/Makefile
+++ b/core/Makefile
@@ -1,6 +1,6 @@
 obj-y+=lib/
 
-INC_DIR+=-I$(shell pwd)/../include -I$(shell pwd)/include -I$(shell pwd)/include  
+INC_DIR+=-I$(shell pwd)/../include -I$(shell pwd)/include  
 
 COMMON_CFLAGS+=$(CONFIG_OPT_CFLAGS)
 COMMON_CFLAGS+= -Wall -g -I$(shell pwd)/include -fPIC  $(INC_DIR)  -Werror


### PR DESCRIPTION
Hi, I found there's a redundant line of include.