### PR TITLE
fix InferShape error of Reshape OP

### DIFF
--- a/operator/operator/reshape.cpp
+++ b/operator/operator/reshape.cpp
@@ -42,10 +42,7 @@ bool Reshape::InferShape(const std::vector<TEngine::TShape>& ishape, std::vector
         {
             if(0 == param_.re_shape[i])
             {
-                if(param_.is_mxnet)
-                    new_shape.push_back(in_dims[in_idx]);
-                else
-                    new_shape.push_back(1);
+                new_shape.push_back(in_dims[i]);
                 in_idx++;
             }
             else if(-1 == param_.re_shape[i])


### PR DESCRIPTION
1. In addition to mxnet, caffe supports Reshape OP with dim=0 as well. [Reference](http://caffe.berkeleyvision.org/tutorial/layers/reshape.html)
2. For dim=0, new_shape should take in_dims[i] but not in_dims[in_idx]. [Reference](http://mxnet.incubator.apache.org/api/python/docs/api/ndarray/ndarray.html?highlight=reshape#mxnet.ndarray.reshape)
3. It seems that other frameworks like tf and pytorch doesn't support dim=0 in Reshape OP, and is it really necessary and right to replace 0 with 1 for other flavour?