### PR TITLE
Delete android_pack.sh

### DIFF
--- a/android_pack.sh
+++ b/android_pack.sh
@@ -1,9 +1,0 @@
-#!/bin/bash
-
-mkdir -p android_pack
-
-cp build/libtengine.so  ./android_pack  
-cp build/libhclcpu.so  ./android_pack
-cp install/lib/libc++_shared.so ./android_pack
-
-


### PR DESCRIPTION
When we build Tengine use the command 'make' and 'make install', 'libc++_shared.so' while be copied to 'install/lib/' directory ，I think we don`t need this script.