### PR TITLE
fix a typo in Graph::IsInputNode

### DIFF
--- a/core/lib/graph.cpp
+++ b/core/lib/graph.cpp
@@ -676,7 +676,7 @@ bool Graph::IsOutputNode(Node* node)
 
 bool Graph::IsInputNode(Node* node)
 {
-    for(unsigned int i = 0; i < output_nodes.size(); i++)
+    for(unsigned int i = 0; i < input_nodes.size(); i++)
     {
         if(input_nodes[i] == node)
             return true;


### PR DESCRIPTION
The old line seems a typo, since it accesses `output_nodes` in `IsInputNode`, so this PR fixes it.