### PR TITLE
Fix onnx flatten

### DIFF
--- a/tools/plugin/serializer/onnx/onnx_serializer.cpp
+++ b/tools/plugin/serializer/onnx/onnx_serializer.cpp
@@ -679,9 +679,13 @@ static bool LoadOnnxFlatten(StaticGraph* graph, StaticNode* node, const onnx::No
 {
     FlattenParam param = any_cast<FlattenParam>(OpManager::GetOpDefParam("Flatten"));
 
-    const onnx::AttributeProto& attr = onnx_node.attribute(0);
+    if (onnx_node.attribute_size() >= 1) {
+        const onnx::AttributeProto& attr = onnx_node.attribute(0);
+        param.axis = attr.i();
+    } else {
+        param.axis = 1;
+    }
 
-    param.axis = attr.i();
 
     StaticOp* op = CreateStaticOp(graph, "Flatten");
 


### PR DESCRIPTION
https://github.com/onnx/onnx/blob/master/docs/Operators.md#Flatten

resnet 18 from onnx model zoo causes segfault of the convert model. The reason is that attribute "axis" of onnx flatten op is optional.