### PR TITLE
fix bug: examples/mobilenet_ssd.cpp

### DIFF
--- a/examples/mobilenet_ssd.cpp
+++ b/examples/mobilenet_ssd.cpp
@@ -220,7 +220,7 @@ int main(int argc, char* argv[])
 
     float show_threshold = 0.5;
 
-    post_process_ssd(image_file, show_threshold, outdata, output_tensor.c);
+    post_process_ssd(image_file, show_threshold, outdata, output_tensor.h);
 
     return 0;
 }


### PR DESCRIPTION
The number of detection boxes in SSD is at the dim H but not C for new API.