### PR TITLE
add pytengine into tengine-lite

### DIFF
--- a/examples/classification.py
+++ b/examples/classification.py
@@ -1,38 +1,50 @@
 from tengine import tg
 import numpy as np
 import cv2
+import argparse
 import os
 import time
 import numpy as np
 
-DEFAULT_MODEL_NAME = "squeezenet"
-DEFAULT_LABEL_FILE = "./models/synset_words.txt"
-DEFAULT_IMG_H = 227
-DEFAULT_IMG_W = 227
-DEFAULT_SCALE = 1.0
+DEFAULT_LABEL_FILE = "./synset_words.txt"
+DEFAULT_IMG_H = 224
+DEFAULT_IMG_W = 224
+DEFAULT_SCALE = 0.017
 DEFAULT_MEAN1 = 104.007
 DEFAULT_MEAN2 = 116.669
 DEFAULT_MEAN3 = 122.679
-DEFAULT_REPEAT_CNT = 1
+
+parser = argparse.ArgumentParser(description='classification')
+parser.add_argument('-m', '--model', default='./mobilenet.tmfile', type=str)
+parser.add_argument('-i', '--image', default='./cat.jpg', type=str)
+parser.add_argument('-g', '--image-size', default=f'{DEFAULT_IMG_H},{DEFAULT_IMG_W}', type=str, help='image size: height, width')
+parser.add_argument('-w', '--mean-value', default=f'{DEFAULT_MEAN1},{DEFAULT_MEAN2},{DEFAULT_MEAN3}', type=str, help='mean value: mean1, mean2, mean3')
+parser.add_argument('-s', '--scale', default=f'{DEFAULT_SCALE}', type=str)
+parser.add_argument('-l', '--label', default=f'{DEFAULT_LABEL_FILE}', type=str, help='the default path of labels.txt (e.g. synset_words.txt)')
 
 def get_current_time():
     return time.time() * 1000
 
-def read_synset_words():
+def read_labels_file(fname):
     outs = []
-    with open('synset_words.txt', 'r') as fin:
+    with open(fname, 'r') as fin:
         for line in fin.readlines():
             outs.append(line.strip())
     return outs
 
-def main():
-    image_file = './cat.jpg'
-    tm_file = './mobilenet.tmfile'
-    assert os.path.exists(tm_file)
-    img_h = 224
-    img_w = 224
-    scale = 0.017
-    img_mean = np.array([DEFAULT_MEAN1, DEFAULT_MEAN2, DEFAULT_MEAN3]).reshape((1, 1, 3))
+def main(args):
+    image_file = args.image
+    tm_file = args.model
+    assert os.path.exists(args.label), f'Label File: {args.label} not found'
+    assert os.path.exists(image_file), f'Image: {image_file} not found'
+    assert os.path.exists(tm_file), f'Model: {tm_file} not found'
+    labels = read_labels_file(args.label)
+
+    img_h, img_w = map(int, args.image_size.split(','))
+    scale = float(args.scale)
+    mean_value = list(map(float, args.mean_value.split(',')))
+    assert len(mean_value) == 3, 'The number of mean_value should be 3, e.g. 104.007,116.669,122.679'
+    img_mean = np.array(mean_value).reshape((1, 1, 3))
     data = cv2.imread(image_file)
     data = cv2.resize(data, (img_w, img_h))
     data = ((data - img_mean) * scale).astype(np.float32)
@@ -49,11 +61,11 @@ def main():
     output_tensor = graph.getOutputTensor(0, 0)
     output = np.array(output_tensor.buf)
 
-    classes = read_synset_words()
     k = 5
     idx = output.argsort()[-1:-k-1:-1]
     for i in idx:
-        print(classes[i], output[i])
+        print(labels[i], output[i])
 
 if __name__ == '__main__':
-    main()
+    args = parser.parse_args()
+    main(args)

--- a/examples/classification.py
+++ b/examples/classification.py
@@ -55,6 +55,5 @@ def main():
     for i in idx:
         print(classes[i], output[i])
 
-
 if __name__ == '__main__':
     main()

--- a/examples/classification.py
+++ b/examples/classification.py
@@ -1,0 +1,60 @@
+from tengine import tg
+import numpy as np
+import cv2
+import os
+import time
+import numpy as np
+
+DEFAULT_MODEL_NAME = "squeezenet"
+DEFAULT_LABEL_FILE = "./models/synset_words.txt"
+DEFAULT_IMG_H = 227
+DEFAULT_IMG_W = 227
+DEFAULT_SCALE = 1.0
+DEFAULT_MEAN1 = 104.007
+DEFAULT_MEAN2 = 116.669
+DEFAULT_MEAN3 = 122.679
+DEFAULT_REPEAT_CNT = 1
+
+def get_current_time():
+    return time.time() * 1000
+
+def read_synset_words():
+    outs = []
+    with open('synset_words.txt', 'r') as fin:
+        for line in fin.readlines():
+            outs.append(line.strip())
+    return outs
+
+def main():
+    image_file = './cat.jpg'
+    tm_file = './mobilenet.tmfile'
+    assert os.path.exists(tm_file)
+    img_h = 224
+    img_w = 224
+    scale = 0.017
+    img_mean = np.array([DEFAULT_MEAN1, DEFAULT_MEAN2, DEFAULT_MEAN3]).reshape((1, 1, 3))
+    data = cv2.imread(image_file)
+    data = cv2.resize(data, (img_w, img_h))
+    data = ((data - img_mean) * scale).astype(np.float32)
+    data = np.ascontiguousarray(data.transpose((2, 0, 1)))
+    assert data.dtype == np.float32
+
+    graph = tg.Graph(None, 'tengine', tm_file)
+    input_tensor = graph.getInputTensor(0, 0)
+    dims = [1, 3, img_h, img_w]
+    input_tensor.shape = dims
+    graph.preRun()
+    input_tensor.buf = data
+    graph.run(1) # 1 is blocking
+    output_tensor = graph.getOutputTensor(0, 0)
+    output = np.array(output_tensor.buf)
+
+    classes = read_synset_words()
+    k = 5
+    idx = output.argsort()[-1:-k-1:-1]
+    for i in idx:
+        print(classes[i], output[i])
+
+
+if __name__ == '__main__':
+    main()

--- a/pytengine/README.md
+++ b/pytengine/README.md
@@ -1,0 +1,15 @@
+### 编译Pytengine
+
+#### 1.安装依赖
+
+~~~
+pip3 install numpy
+sudo yum install python3-opencv
+~~~
+
+#### 2. 安装pytengine
+
+~~~
+sudo python3 setup.py install --prefix=/usr/
+~~~
+

--- a/pytengine/setup.py
+++ b/pytengine/setup.py
@@ -1,0 +1,18 @@
+#!/usr/bin/env python
+
+# coding: utf-8
+from setuptools import setup, Extension
+
+# from distutils.core import setup, Extension
+
+files = ["__init__", "base", "context", "device", "graph", "libinfo", "node", "tengine", "tensor"]
+
+setup(name="pytengine",
+      version="0.9.1",
+      description="Tengine is a software development kit for front-end intelligent devices developed by OPENAILAB",
+      author="OpenAILab",
+      author_email="OpenAILab@126.com",
+      url="https://github.com/OAID/Tengine",
+      packages=["tengine"],
+      install_requires=['numpy>=1.4.0']
+      )

--- a/pytengine/tengine/__init__.py
+++ b/pytengine/tengine/__init__.py
@@ -1,0 +1,9 @@
+#!/usr/bin/env python
+
+# coding: utf-8
+"""Tengine is a software development kit for front-end intelligent devices developed by OPENAILAB"""
+
+
+
+from .tengine import tg
+

--- a/pytengine/tengine/base.py
+++ b/pytengine/tengine/base.py
@@ -1,0 +1,383 @@
+# coding: utf-8
+# pylint: disable=invalid-name, no-member, trailing-comma-tuple, bad-mcs-classmethod-argument
+"""ctypes library of tegine and helper functions."""
+from __future__ import absolute_import
+
+import atexit
+import ctypes
+import os
+import sys
+import inspect
+import platform
+import numpy as np
+
+from . import libinfo
+
+# pylint: disable=pointless-statement
+try:
+    basestring
+    long
+except NameError:
+    basestring = str
+    long = int
+# pylint: enable=pointless-statement
+
+integer_types = (int, long, np.int32, np.int64)
+numeric_types = (float, int, long, np.generic)
+string_types = basestring,
+MAX_SHAPE_DIM_NUM = 4
+
+if sys.version_info[0] > 2:
+    # this function is needed for python3
+    # to convert ctypes.char_p .value back to python str
+    py_str = lambda x: x.decode('utf-8')
+else:
+    py_str = lambda x: x
+
+log_print_t = ctypes.CFUNCTYPE(ctypes.c_void_p,ctypes.c_char_p)
+event_handler_t = ctypes.CFUNCTYPE(ctypes.c_int,ctypes.c_void_p,ctypes.c_int,ctypes.c_void_p)
+
+def data_dir_default():
+    """
+
+    :return: default data directory depending on the platform and environment variables
+    """
+    system = platform.system()
+    return os.path.join(os.path.expanduser("~"), '.tengine')
+
+
+def data_dir():
+    """
+
+    :return: data directory in the filesystem for storage, for example when downloading models
+    """
+    return os.getenv('TENGINE_HOME', data_dir_default())
+
+
+class _NullType(object):
+    """Placeholder for arguments"""
+
+    def __repr__(self):
+        return '_Null'
+
+
+_Null = _NullType()
+
+
+class TytengineError(Exception):
+    """Error that will be throwed by all tengine functions."""
+    pass
+
+
+class TGCallbackList(ctypes.Structure):
+    """Structure that holds Callback information. Passed to CustomOpProp."""
+    _fields_ = [
+        ('num_callbacks', ctypes.c_int),
+        ('callbacks', ctypes.POINTER(ctypes.CFUNCTYPE(ctypes.c_int))),
+        ('contexts', ctypes.POINTER(ctypes.c_void_p))
+    ]
+
+
+def _load_lib():
+    """Load library by searching possible path."""
+    lib_path = libinfo.find_lib_path()
+    lib = ctypes.CDLL(lib_path[0], ctypes.RTLD_GLOBAL)
+    # DMatrix functions
+    return lib
+
+
+# version number
+__version__ = libinfo.__version__
+_LIB = _load_lib()
+
+# type definitions
+context_t = ctypes.c_void_p
+graph_t = ctypes.c_void_p
+node_t = ctypes.c_void_p
+tensor_t = ctypes.c_void_p
+
+
+# ----------------------------
+# helper function definition
+# ----------------------------
+def check_call(ret):
+    if ret != 0:
+        raise TytengineError(_LIB.get_tengine_errno())
+
+
+if sys.version_info[0] < 3:
+    def c_str(string):
+        if not string:
+            return None
+        return ctypes.c_char_p(string)
+
+
+    def c_str_array(strings):
+        arr = (ctypes.c_char_p * len(strings))()
+        arr[:] = strings
+        return arr
+
+else:
+    def c_str(string):
+        if not string:
+            return None
+        return ctypes.c_char_p(string.encode('utf-8'))
+
+
+    def c_str_array(strings):
+        arr = (ctypes.c_char_p * len(strings))()
+        arr[:] = [s.encode('utf-8') for s in strings]
+        return arr
+
+
+def c_array(ctype, values):
+    out = (ctype * len(values))()
+    out[:] = values
+    return out
+
+
+def c_array_buf(ctype, buf):
+    return (ctype * len(buf)).from_buffer(buf)
+
+
+def c_handle_array(objs):
+    arr = (ctypes.c_void_p * len(objs))()
+    arr[:] = [o.handle for o in objs]
+    return arr
+
+
+def ctypes2buffer(cptr, length):
+    if not isinstance(cptr, ctypes.POINTER(ctypes.c_char)):
+        raise TypeError('expected char pointer')
+    res = bytearray(length)
+    rptr = (ctypes.c_char * length).from_buffer(res)
+    if not ctypes.memmove(rptr, cptr, length):
+        raise RuntimeError('memmove failed')
+    return res
+
+
+def ctypes2numpy_shared(cptr, shape, type=ctypes.c_int):
+    if not isinstance(cptr, ctypes.POINTER(type)):
+        raise RuntimeError('expected float pointer')
+    size = 1
+    for s in shape:
+        size *= s
+    dbuffer = (type * size).from_address(ctypes.addressof(cptr.contents))
+    if type == ctypes.c_int:
+        return np.frombuffer(dbuffer, dtype=np.int32).reshape(shape)
+    elif type == ctypes.c_float:
+        return np.frombuffer(dbuffer, dtype=np.float32).reshape(shape)
+
+
+def build_param_doc(arg_names, arg_types, arg_descs, remove_dup=True):
+    param_keys = set()
+    param_str = []
+    for key, type_info, desc in zip(arg_names, arg_types, arg_descs):
+        if key in param_keys and remove_dup:
+            continue
+        if key == 'num_args':
+            continue
+        param_keys.add(key)
+        ret = '%s : %s' % (key, type_info)
+        if len(desc) != 0:
+            ret += '\n    ' + desc
+        param_str.append(ret)
+    doc_str = ('Parameters\n' +
+               '----------\n' +
+               '%s\n')
+    doc_str = doc_str % ('\n'.join(param_str))
+    return doc_str
+
+
+Tengine_type = [
+    'TENGINE_DT_FP32',
+    'TENGINE_DT_FP16',
+    'TENGINE_DT_INT8',
+    'TENGINE_DT_UINT8',
+    'TENGINE_DT_INT32',
+    'TENGINE_DT_INT16'
+]
+Tengine_ctype = [
+    ctypes.c_float,
+    ctypes.c_void_p,  # float 16
+    ctypes.c_int8,
+    ctypes.c_uint8,
+    ctypes.c_int32,
+    ctypes.c_int16,
+]
+
+
+class DType:
+    def __init__(self, enum):
+        self.enum = enum
+        pass
+
+    def __str__(self):
+        return "<Tegine dtype :%s>" % Tengine_type[self.enum]
+
+    def __repr__(self):
+        return "<Tegine dtype :%s>" % Tengine_type[self.enum]
+
+
+graph_exec_stat = [
+    'GRAPH_STAT_CREATED',
+    'GRAPH_STAT_READY',
+    'GRAPH_STAT_RUNNING',
+    'GRAPH_STAT_DONE',
+    'GRAPH_STAT_ERROR'
+]
+
+
+class Status:
+    def __init__(self, enum):
+        self.enum = enum
+
+    def __str__(self):
+        return "<graph exec status :%s>" % graph_exec_stat[self.enum]
+
+    def __repr__(self):
+        return "<graph exec status  :%s>" % graph_exec_stat[self.enum]
+
+
+graph_exec_event = [
+    'GRAPH_EXEC_START',
+    'GRAPH_EXEC_SUSPEND',
+    'GRAPH_EXEC_RESUME',
+    'GRAPH_EXEC_ABORT',
+    'GRAPH_EXEC_DONE'
+]
+
+
+class Event:
+    def __init__(self, enum):
+        self.enum = enum
+
+    def __str__(self):
+        return "<graph exec event :%s>" % graph_exec_event[self.enum]
+
+    def __repr__(self):
+        return "<graph exec event  :%s>" % graph_exec_event[self.enum]
+
+
+device_policy = [
+    'DEFAULT_POLICY',
+    'LATENCY_POLICY',
+    'LOW_POWER_POLICY'
+]
+
+
+class Policy:
+    def __init__(self, enum):
+        self.enum = enum
+
+    def __str__(self):
+        return "<device_policy :%s>" % device_policy[self.enum]
+
+    def __repr__(self):
+        return "<device_policy  :%s>" % device_policy[self.enum]
+
+
+def _notify_shutdown():
+    """Notify Tengine about a shutdown."""
+    print("release tengine")
+    check_call(_LIB.release_tengine())
+    pass
+
+
+atexit.register(_notify_shutdown)
+
+
+class tensor_dump_header(ctypes.Structure):
+    _fields_ = [('elem_size', ctypes.c_int),
+                ('elem_number', ctypes.c_int),
+                ('dim_number', ctypes.c_int),
+                ('dim', ctypes.c_int * 4),
+                ('data', ctypes.c_void_p)]
+
+
+class perf_info(ctypes.Structure):
+    _fields_ = [('name', ctypes.c_char_p), ('dev_name', ctypes.c_char_p),
+                ('count', ctypes.c_uint32), ('min', ctypes.c_uint32),
+                ('max', ctypes.c_uint32), ('total_time', ctypes.c_uint64),
+                ('base', ctypes.c_uint32)]
+
+
+class custom_kernel_tensor(ctypes.Structure):
+    _fields_ = [('dim', (ctypes.c_int * MAX_SHAPE_DIM_NUM)),
+                ('dim_num', ctypes.c_int),
+                ('element_num', ctypes.c_int),
+                ('element_size', ctypes.c_int),
+                ('data_type', ctypes.c_int),
+                ('dev_type', ctypes.c_int),
+                ('layout_type', ctypes.c_int),
+                ('quant_type', ctypes.c_int),
+                ('scale', ctypes.POINTER(ctypes.c_float)),
+                ('zero_point', ctypes.POINTER(ctypes.c_int)),
+                ('quant_number', ctypes.POINTER(ctypes.c_int)),
+                ('data', ctypes.c_void_p),
+                ('dev_mem', ctypes.c_void_p),
+                ('mapped_mem', ctypes.c_void_p)]
+
+
+class custom_kernel_ops(ctypes.Structure):
+    pass
+
+
+function_type_infer_shape = ctypes.CFUNCTYPE(ctypes.c_int, ctypes.POINTER(custom_kernel_ops),
+                                             ctypes.POINTER(ctypes.POINTER(ctypes.c_int)),
+                                             ctypes.c_int, ctypes.POINTER(ctypes.POINTER(ctypes.c_int)), ctypes.c_int,
+                                             ctypes.c_int)
+function_type_inplace_info = ctypes.CFUNCTYPE(ctypes.c_int, ctypes.POINTER(custom_kernel_ops), ctypes.c_int)
+
+function_type_bind = ctypes.CFUNCTYPE(ctypes.c_int, ctypes.POINTER(custom_kernel_ops),
+                                      ctypes.POINTER(ctypes.POINTER(custom_kernel_tensor)), ctypes.c_int,
+                                      ctypes.POINTER(ctypes.POINTER(custom_kernel_tensor)), ctypes.c_int)
+
+function_type_prerun = ctypes.CFUNCTYPE(ctypes.c_int, ctypes.POINTER(custom_kernel_ops),
+                                        ctypes.POINTER(ctypes.POINTER(custom_kernel_tensor)),
+                                        ctypes.c_int, ctypes.POINTER(ctypes.POINTER(custom_kernel_tensor)),
+                                        ctypes.c_int, ctypes.c_int)
+
+function_type_reshape = ctypes.CFUNCTYPE(ctypes.c_int, ctypes.POINTER(custom_kernel_ops),
+                                         ctypes.POINTER(ctypes.POINTER(custom_kernel_tensor)),
+                                         ctypes.c_int, ctypes.POINTER(ctypes.POINTER(custom_kernel_tensor)),
+                                         ctypes.c_int)
+
+function_type_run = ctypes.CFUNCTYPE(ctypes.c_int, ctypes.POINTER(custom_kernel_ops),
+                                     ctypes.POINTER(ctypes.POINTER(custom_kernel_tensor)),
+                                     ctypes.c_int, ctypes.POINTER(ctypes.POINTER(custom_kernel_tensor)), ctypes.c_int)
+
+function_type_postrun = ctypes.CFUNCTYPE(ctypes.c_int, ctypes.POINTER(custom_kernel_ops),
+                                         ctypes.POINTER(ctypes.POINTER(custom_kernel_tensor)),
+                                         ctypes.c_int, ctypes.POINTER(ctypes.POINTER(custom_kernel_tensor)),
+                                         ctypes.c_int)
+
+function_type_release = ctypes.CFUNCTYPE(ctypes.c_int, ctypes.POINTER(custom_kernel_ops))
+
+custom_kernel_ops._fields_ = [('kernel_name', ctypes.c_char_p),
+                              ('op', ctypes.c_char_p),
+                              ('force', ctypes.c_int),
+                              ('kernel_param', ctypes.c_void_p),
+                              ('kernel_param_size', ctypes.c_int),
+                              ('infer_shape', function_type_infer_shape),
+                              ('inplace_info', function_type_inplace_info),
+                              ('bind', function_type_bind),
+                              ('prerun', function_type_prerun),
+                              ('reshape', function_type_reshape),
+                              ('run', function_type_run),
+                              ('postrun', function_type_postrun),
+                              ('release', function_type_release)]
+
+
+class cpu_cluster(ctypes.Structure):
+    _fields_ = [('cpu_number', ctypes.c_int), ('max_freq', ctypes.c_int),
+                ('cpu_model', ctypes.c_int), ('cpu_arch', ctypes.c_int),
+                ('l1_size', ctypes.c_int), ('l2_size', ctypes.c_int),
+                ('hw_cpu_id', ctypes.c_int * 8)]
+
+
+class cpu_info(ctypes.Structure):
+    _fields_ = [('cpu_name', ctypes.c_char_p), ('board_name', ctypes.c_char_p),
+                ('cluster_number', ctypes.c_int), ('l3_size', ctypes.c_int),
+                ('cpu_cluster', ctypes.POINTER(cpu_cluster)), ('online_cpu_number', ctypes.c_int),
+                ('online_cpu_list', ctypes.c_int * 4)]

--- a/pytengine/tengine/base.py
+++ b/pytengine/tengine/base.py
@@ -277,16 +277,6 @@ class Policy:
         return "<device_policy  :%s>" % device_policy[self.enum]
 
 
-def _notify_shutdown():
-    """Notify Tengine about a shutdown."""
-    print("release tengine")
-    check_call(_LIB.release_tengine())
-    pass
-
-
-atexit.register(_notify_shutdown)
-
-
 class tensor_dump_header(ctypes.Structure):
     _fields_ = [('elem_size', ctypes.c_int),
                 ('elem_number', ctypes.c_int),

--- a/pytengine/tengine/context.py
+++ b/pytengine/tengine/context.py
@@ -1,0 +1,102 @@
+# coding: utf-8
+"""Information about Tengine."""
+import ctypes
+from .base import _LIB,c_str,context_t, check_call
+
+
+class Context(object):
+    def __init__(self, name, empty=True):
+        """
+        create one execution context with name
+        :param name: <str> name of the created context
+        :param empty: <bool> True: no device assigned , False: all proved devices will be assigned
+        """
+        self.__attr__ = {}
+        _LIB.create_context.restype = context_t
+        self.context = _LIB.create_context(c_str(name), empty)
+        pass
+
+    def __del__(self):
+        """
+        destory and reclaim the resource related with the context
+        :return:
+        """
+        _LIB.destroy_context(ctypes.c_void_p(self.context))
+
+    def getDevNumber(self):
+        """
+        get the device number assigned to a context
+        :return: <int> numbers of the context device
+        """
+        return _LIB.get_context_device_number(ctypes.c_void_p(self.context))
+
+    def getDevByIdx(self, idx):
+        """
+        get the name of the idx device in a context
+        :param idx: <int> 0,1,...,
+        :return <str> name of the device
+
+        """
+        _LIB.get_context_device_name.restype = ctypes.c_char_p
+        return _LIB.get_context_device_name(ctypes.c_void_p(self.context), idx)
+
+    def addDev(self,dev_name):
+        """
+        add a device into one context
+        :param dev_name: <str> name of the device (created by user)
+        :return: <int> 0: success , -1 : Fail.
+        """
+        check_call(_LIB.add_context_device(ctypes.c_void_p(self.context), c_str(dev_name)))
+
+    def rmDev(self,dev_name):
+        """
+        remove a device from one context
+        :param dev_name: <str> name of the device (created by user)
+        :return: <int> 0: success , -1 : Fail.
+        """
+        return _LIB.remove_context_device(ctypes.c_void_p(self.context), c_str(dev_name))
+
+    def setAttr(self,attr,obj):
+        """
+        set attribute item of a context
+        :param attr: <str> attr_name, the attribute item name.
+        :param obj: <int> or <float> or <str> or <list> the data want to set
+        :return: None
+        """
+        if type(obj) is int:
+            buf = (ctypes.c_int * 1)(obj)
+            check_call(_LIB.set_context_attr(ctypes.c_void_p(self.context),c_str(attr),ctypes.cast(buf,ctypes.POINTER(ctypes.c_int)),ctypes.sizeof(ctypes.c_int)))
+        elif type(obj) is float:
+            buf = (ctypes.c_float * 1)(obj)
+            check_call(_LIB.set_context_attr(ctypes.c_void_p(self.context), c_str(attr),
+                                             ctypes.cast(buf, ctypes.POINTER(ctypes.c_float)),
+                                             ctypes.sizeof(ctypes.c_float)))
+        elif type(obj) is str:
+            buf = ctypes.create_string_buffer(obj,len(obj))
+            check_call(_LIB.set_context_attr(ctypes.c_void_p(self.context), c_str(attr),
+                                             ctypes.cast(buf, ctypes.POINTER(ctypes.c_char)),
+                                             ctypes.sizeof(ctypes.c_char)*len(obj)))
+        elif type(obj) is list:
+            if type(obj[0]) is int:
+                buf = (ctypes.c_int * len(obj))(*obj)
+                check_call(_LIB.set_context_attr(ctypes.c_void_p(self.context), c_str(attr),
+                                                 ctypes.cast(buf, ctypes.POINTER(ctypes.c_int)),
+                                                 ctypes.sizeof(ctypes.c_int)*len(obj)))
+            elif type(obj[0]) is float:
+                buf = (ctypes.c_float * len(obj))(*obj)
+                check_call(_LIB.set_context_attr(ctypes.c_void_p(self.context), c_str(attr),
+                                                 ctypes.cast(buf, ctypes.POINTER(ctypes.c_float)),
+                                                 ctypes.sizeof(ctypes.c_float)*len(obj)))
+        else:
+            print("not surpported type: {} yet.".format(type(obj)))
+
+    def getAttr(self,attr_name,size):
+        """
+        get the attribute item of a context
+        :param attr_name: <str> the attribute item name
+        :param size: <int> the buffer size
+        :return: data buffer
+        """
+        buf = ctypes.create_string_buffer('',size=size)
+        check_call(_LIB.get_context_attr(ctypes.c_void_p(self.context),c_str(attr_name)),ctypes.cast(buf,ctypes.POINTER(ctypes.c_char),size))
+

--- a/pytengine/tengine/device.py
+++ b/pytengine/tengine/device.py
@@ -1,0 +1,73 @@
+# coding: utf-8
+"""Information about Tengine."""
+
+from .base import _LIB, check_call, c_str
+import ctypes
+
+class Device(object):
+    def __init__(self, driver_name=None, dev_name=None):
+        """
+        create device, for predefined device but driver does not auto probed device
+        :param driver_name: <str> the driver name
+        :param dev_name: <str> the device name
+        """
+        check_call(_LIB.create_device(c_str(driver_name), c_str(dev_name)))
+        self.driver = [driver_name, dev_name]
+        pass
+
+    def __del__(self):
+        """
+        destroy device, for predefined device but driver does not auto probed device.
+        :return:
+        """
+        if self.driver:
+            check_call(_LIB.destroy_device(*self.driver))
+        self.driver = None
+
+    def getAttr(self, item,size):
+        buf = ctypes.create_string_buffer('',size=size)
+        check_call(_LIB.get_device_attr(c_str(self.driver[1]),c_str(item),ctypes.cast(buf,ctypes.POINTER(ctypes.c_char)),size))
+        return buf[:size]
+
+    def setAttr(self,item,obj):
+        if type(obj) is int:
+            buf = (ctypes.c_int * 1)(obj)
+            check_call(_LIB.set_device_attr(c_str(self.driver[1]),c_str(item),ctypes.cast(buf,ctypes.POINTER(ctypes.c_int)),ctypes.sizeof(ctypes.c_int)))
+        elif type(obj) is float:
+            buf = (ctypes.c_float * 1)(obj)
+            check_call(_LIB.set_device_attr(c_str(self.driver[1]),c_str(item),ctypes.cast(buf,ctypes.POINTER(ctypes.c_int)),ctypes.sizeof(ctypes.c_float)))
+        elif type(obj) is str:
+            buf = ctypes.create_string_buffer(obj,len(obj))
+            check_call(
+                _LIB.set_device_attr(c_str(self.driver[1]), c_str(item), ctypes.cast(buf, ctypes.POINTER(ctypes.c_char)),
+                                     ctypes.sizeof(ctypes.c_char)*len(obj)))
+        elif type(obj) is list:
+            if type(obj[0]) is int:
+                buf = (ctypes.c_int * len(obj))(*obj)
+                check_call(_LIB.set_device_attr(c_str(self.driver[1]), c_str(item),
+                                                ctypes.cast(buf, ctypes.POINTER(ctypes.c_int)),
+                                                ctypes.sizeof(ctypes.c_int)*len(obj)))
+            elif type(obj[0]) is float:
+                buf = (ctypes.c_float*len(obj))(*obj)
+                check_call(_LIB.set_device_attr(c_str(self.driver[1]), c_str(item),
+                                                ctypes.cast(buf, ctypes.POINTER(ctypes.c_float)),
+                                                ctypes.sizeof(ctypes.c_float)*len(obj)))
+        else:
+            print("not support type: {} yet.".format(type(obj)))
+
+    @property
+    def policy(self):
+        """
+        get the device working mode.
+        :return: <int> >= 0 : the mode, -1: fail.
+        """
+        return _LIB.get_device_policy(c_str(self.driver[1]))
+
+    @policy.setter
+    def policy(self, policy):
+        """
+        set the device working policy.
+        :param policy:
+        :return:
+        """
+        return _LIB.set_device_policy(c_str(self.driver[1]), policy)

--- a/pytengine/tengine/graph.py
+++ b/pytengine/tengine/graph.py
@@ -1,0 +1,362 @@
+# coding: utf-8
+"""Information about Tengine."""
+
+import ctypes
+import numpy as np
+from .base import _LIB, c_str, graph_t, node_t, tensor_t, Status, perf_info, check_call, event_handler_t
+from .tensor import Tensor
+from .node import Node
+import time
+
+class Graph(object):
+    def __init__(self, context=None, model=None, *kwarg):
+        """
+        create the run-time graph for execution from a saved model
+        if model is None, an empty graph will be created
+        :param context: <context object> or None. the context for this graph to run inside
+        :param model: <str> model format : caffe , mxnet , tengine , ...
+        :param kwarg: the path of the model file
+        """
+        _LIB.create_graph.restype = graph_t
+        if context:
+            context = context.context
+        if model:
+            params = [ c_str(kwarg[i]) for i in range(len(kwarg)) ]
+            self.graph = _LIB.create_graph(ctypes.c_void_p(context), c_str(model), *params)
+        else:
+            self.graph = _LIB.create_graph(ctypes.c_void_p(context), None)
+        self.attr = {}
+        pass
+
+    def __del__(self):
+        """
+        destory the run-time graph and release allocated resource.
+        :return:
+        """
+        if self.graph:
+            _LIB.destroy_graph(ctypes.c_void_p(self.graph))
+        self.graph = None
+        pass
+
+    def __getitem__(self, idx):
+        """
+        get the output node by idx
+        :param idx: <int> like: 0,1,2,...
+        :return: <node object> output node object
+        """
+        return self.getNodeByIdx(idx)
+
+    def setEvent(self,event,cb_func,cb_arg):
+        """
+        set the event hook for graph execution
+        :param event: the event to be hooked
+        :param cb_func: the callback function
+        :param cb_arg: the argument will be passed to callback function
+        :return: None
+        """
+        check_call(_LIB.set_graph_event_hook(ctypes.c_void_p(self.graph),event,event_handler_t(cb_func),ctypes.pointer(cb_arg)))
+
+    def save(self, model, *kwarg):
+        """
+        save the graph into file using the model format
+        :param model: <str> model format
+        :param kwarg: <str> save file path
+        :return: 0: success, -1: fail
+        """
+        params = [c_str(item) for item in kwarg]
+        return _LIB.save_graph(ctypes.c_void_p(self.graph), c_str(model), *params)
+
+    def quant(self, mode, idxs):
+        """
+        quant the graph according to the quant mode
+        :param mode: <quant_mode> like: tg.TENGINE_QUANT_FP16 etc.
+        :param idxs: <list> list of nodes not quant
+        :return:
+        """
+        _LIB.quant_graph.argtypes = [ctypes.c_void_p,ctypes.c_int,ctypes.POINTER(ctypes.c_int),ctypes.c_int]
+        return _LIB.quant_graph(ctypes.c_void_p(self.graph), mode, np.ctypeslib.as_ctypes(idxs), len(idxs))
+
+    def setlayout(self, type):
+        """
+        set the layer type of the graph
+        :param type: <layout_type> like: tg.TENGINE_LAYOUT_NCHW, tg.TENGINE_LAYOUT_NHWC
+        :return: 0: success, -1: fail
+        """
+        return _LIB.set_graph_layout(ctypes.c_void_p(self.graph), type)
+
+    def setNode(self, input_nodes=[], output_nodes=[]):
+        """
+        designate the input nodes and output nodes of the graph
+        :param input_nodes: <list> the node name list of input nodes
+        :param output_nodes: <list> the node name list of output nodes
+        :return:
+        """
+        if len(input_nodes) != 0:
+            num = len(input_nodes)
+            c_arr_buf = ctypes.c_char_p * num
+            input_ = [c_str(item) for item in input_nodes]
+            c_arr = c_arr_buf(*input_)
+            check_call(_LIB.set_graph_input_node(ctypes.c_void_p(self.graph), c_arr, num))
+            pass
+        if len(output_nodes) != 0:
+            num = len(output_nodes)
+            c_arr_buf = ctypes.c_char_p * num
+            output_ = [c_str(item) for item in output_nodes]
+            c_arr = c_arr_buf(*output_)
+            check_call(_LIB.set_graph_output_node(ctypes.c_void_p(self.graph), c_arr, num))
+            pass
+
+    def __add__(self, *other):
+        """
+        merge several graph into this graph, important: all graphs should be in the same context
+        :param other: <graph objects>
+        :return:
+        """
+        _LIB.merge_graph.restype = graph_t
+        c_graph = [ctypes.c_void_p(p) for p in other]
+        graph = _LIB.merge_graph(ctypes.c_void_p(self.graph), *c_graph)
+        return Graph(graph=graph)
+
+    def getInputNodeNumber(self):
+        """
+        get the number of input nodes of the graph
+        :return: <int> number of input nodes
+        """
+        return _LIB.get_graph_input_node_number(self.graph)
+
+    def getInputNodeByIdx(self, idx):
+        """
+        get the node object by the index of input node of this graph
+        :param idx: <idx> index of the input nodes
+        :return: <node object>
+        """
+        _LIB.get_graph_input_node = node_t
+        node = _LIB.get_graph_input_node(ctypes.c_void_p(self.graph), idx)
+        return Node(node=node)
+
+    def getOutputNodeNumber(self):
+        """
+        get the number of the output nodes of this graph
+        :return: number of the output nodes
+        """
+        return _LIB.get_graph_output_node_number(ctypes.c_void_p(self.graph))
+
+    def getOutputNodeByIdx(self, idx):
+        """
+        get the node object by the index of the output node of this graph
+        :param idx: <int> index of the output node
+        :return: <node object>
+        """
+        _LIB.get_graph_output_node.restype = node_t
+        node = _LIB.get_graph_output_node(ctypes.c_void_p(self.graph), idx)
+        return Node(node=node)
+
+    def getOutputTensor(self, nodeidx, idx):
+        """
+        get the tensor object of a graph output node
+        :param nodeidx: <int> the output node index.
+        :param idx: <int> the output tensor index of the output node.
+        :return: <tensor object>
+        """
+        _LIB.get_graph_output_tensor.restype = tensor_t
+        tensor = _LIB.get_graph_output_tensor(ctypes.c_void_p(self.graph), nodeidx, idx)
+        return Tensor(tensor=tensor)
+
+    def getInputTensor(self, nodeidx, idx):
+        """
+        get a tensor object of this graph input tensor
+        :param nodeidx: <int> input node index
+        :param idx:  <int> the output tensor index of the input node
+        :return:
+        """
+        _LIB.get_graph_input_tensor.restype = tensor_t
+        tensor = _LIB.get_graph_input_tensor(ctypes.c_void_p(self.graph), nodeidx, idx)
+        return Tensor(tensor=tensor)
+
+    def getNodeByName(self, name):
+        """
+        get the node object of the graph.
+        :param name: <str> the node name
+        :return: <node object>
+        """
+        _LIB.get_graph_node.restype = node_t
+        node = _LIB.get_graph_node(ctypes.c_void_p(self.graph), c_str(name))
+        return Node(node=node)
+
+    def getNodeNumber(self):
+        """
+        get graph node number.
+        :return: >=0: the number of the graph node, -1: on error
+        """
+        return _LIB.get_graph_node_number(ctypes.c_void_p(self.graph))
+
+    def getNodeByIdx(self, idx):
+        """
+        get graph node by index
+        :param idx: <int> the node index
+        :return: <node object>
+        """
+        _LIB.get_graph_node_by_idx = node_t
+        node = _LIB.get_graph_node_by_idx(ctypes.c_void_p(self.graph), idx)
+        return Node(node=node)
+
+    def getTensorByName(self, name):
+        """
+        get a tensor object by tensor name
+        :param name: <str> name of the tensor
+        :return: <tensor object>
+        """
+        _LIB.get_graph_tensor.restype = tensor_t
+        tensor = _LIB.get_graph_tensor(ctypes.c_void_p(self.graph), c_str(name))
+        return Tensor(tensor=tensor)
+
+    def setAttr(self, attr_name, obj):
+        """
+        to set proprietary attribute items for graph, for the backend device to run
+        :param attr_name:<str> the attribute name
+        :param obj: <int> or <float> or <str> attribute value
+        :return: 0: success, -1: fail.
+        """
+        if type(obj) == type(0):
+            i_inp = (ctypes.c_int*1)(obj)
+            self.attr[attr_name] = {'type': type(obj), 'len': ctypes.sizeof(i_inp)}
+            return _LIB.set_graph_attr(ctypes.c_void_p(self.graph), c_str(attr_name), ctypes.cast(i_inp,ctypes.POINTER(ctypes.c_int)),
+                                ctypes.sizeof(i_inp))
+        elif type(obj) == type(0.1):
+            f_inp = (ctypes.c_float*1)(obj)
+            self.attr[attr_name] = {'type': type(obj), 'len': ctypes.sizeof(f_inp)}
+            return _LIB.set_graph_attr(ctypes.c_void_p(self.graph), c_str(attr_name), ctypes.cast(f_inp,ctypes.POINTER(ctypes.c_float)),
+                                ctypes.sizeof(f_inp))
+        elif type(obj) == type(""):
+            self.attr[attr_name] = {'type': type(obj), 'len': ctypes.sizeof(ctypes.c_char('a')) * len(obj)}
+            buf = ctypes.create_string_buffer(obj)
+            return _LIB.set_graph_attr(ctypes.c_void_p(self.graph), c_str(attr_name), buf,
+                                ctypes.sizeof(ctypes.c_char('a')) * len(obj))
+        pass
+
+    def getAttr(self, attr_name):
+        """
+        get proprietary config items for graph. it is probabaly the config will be passed to the DLA driver.
+        :param attr_name: <str> the attribute name
+        :return: <int> or <float> or <str>
+        """
+        if self.attr[attr_name]['type'] == type(0):
+            buf = (ctypes.c_int*1)(0)
+            _LIB.get_graph_attr(ctypes.c_void_p(self.graph), c_str(attr_name), ctypes.byref(buf),
+                                self.attr[attr_name]['len'])
+            return buf
+        elif self.attr[attr_name]['type'] == type(0.1):
+            buf = (ctypes.c_float*1)(0.0)
+            _LIB.get_graph_attr(ctypes.c_void_p(self.graph), c_str(attr_name), ctypes.cast(buf,ctypes.POINTER(ctypes.c_float)),
+                                self.attr[attr_name]['len'])
+            return buf
+        elif self.attr[attr_name]['type'] == type("a"):
+            buf = ctypes.create_string_buffer("",self.attr[attr_name]['len'])
+            _LIB.get_graph_attr(ctypes.c_void_p(self.graph), c_str(attr_name), ctypes.byref(buf),
+                                self.attr[attr_name]['len'])
+            return buf[:]
+        else:
+            return None
+
+    def setGdMethod(self, methor,*params):
+        """
+        set the gradient descent method
+        :param methor: <int>[<int> ...] the gradient descent.
+        :return: 0: success, -1 fail.
+        """
+        check_call(_LIB.set_graph_gd_method(ctypes.c_void_p(self.graph), methor,*params))
+
+    def preRun(self):
+        """
+        Initialize resource for graph execution
+        :return: None
+        """
+        check_call(_LIB.prerun_graph(ctypes.c_void_p(self.graph)))
+
+    def run(self, block=0):
+        """
+        execute graph
+        :param block: 0: no_blocking,1 : blocking
+        :return: None
+        """
+        check_call(_LIB.run_graph(ctypes.c_void_p(self.graph), block))
+
+    def wait(self, try_wait=0):
+        """
+        wait graph execution done
+        :param try_wait: <bool> if set, just check status and return
+        :return: 1: graph is done, 0: try again
+        """
+        return _LIB.wait_graph(ctypes.c_void_p(self.graph), try_wait)
+
+    def postRun(self):
+        """
+        release the resource for graph execution.
+        :return:None
+        """
+        check_call( _LIB.postrun_graph(ctypes.c_void_p(self.graph)))
+
+    @property
+    def __status__(self):
+        """
+        get the status of graph execution
+        :return: <status>
+        """
+        ret = _LIB.get_graph_exec_status(ctypes.c_void_p(self.graph))
+        return Status(ret)
+
+    def setDevice(self, dev_name):
+        """
+        set the device to execution a graph
+        :param dev_name: <str> The device name to run the node.
+        :return: 0 : success, <0 : error
+        """
+        return _LIB.set_graph_device(ctypes.c_void_p(self.graph), c_str(dev_name))
+
+    def doPerfStat(self, action):
+        """
+        start or stop the perf stats
+        :param action: <int> 0 stop, 1 start, 2 reset counter
+        :return: 0: success, -1: fail
+        """
+        return _LIB.do_graph_perf_stat(ctypes.c_void_p(self.graph), action)
+
+    def getPerfStat(self, size):
+        """
+        get graph performance stats records
+        If the returned number equals buf_size, there may be som records do not be
+        retrieved yet
+        :param size: <int> the number of record pointer may be stored in buf
+        :return: <perf_info list>
+        """
+        info = (perf_info*size)(None)
+        _LIB.get_graph_perf_stat(ctypes.c_void_p(self.graph), ctypes.byref(info), size)
+        return info
+
+    def dump(self):
+        """
+        Dump the run-time graph.
+        Note: If the graph is dumpped after prerun(), it will dump the optimized graph instead of the origin one.
+        :return: None
+        """
+        check_call(_LIB.dump_graph(self.graph))
+
+    def set_input(self,image,shape,input_tensor,mean=[0,0,0],scale=1):
+        """
+        set graph input data and shape here. it will do some simple pre-treatment here
+        :param image: <list> or <ndarray> : input data
+        :param shape: <list> shape
+        :param input_tensor: one input tensor of this graph to set
+        :param mean: <list> mean value
+        :param scale: <float> scale value
+        :return: None
+        """
+
+        data = image
+        if type(data) is np.ndarray:
+            data = data.swapaxes(1,2)
+            data = data.swapaxes(0,1)
+            data = data.flatten()
+        input_tensor.shape = shape
+        input_tensor.buf = data
+        pass

--- a/pytengine/tengine/libinfo.py
+++ b/pytengine/tengine/libinfo.py
@@ -1,0 +1,55 @@
+
+# coding: utf-8
+"""Information about Tengine."""
+from __future__ import absolute_import
+import os
+import platform
+import logging
+
+
+def find_lib_path():
+    """Find Tengine dynamic library files.
+
+    Returns
+    -------
+    lib_path : list(string)
+        List of all found path to the libraries.
+    """
+    dll_path = []
+    curr_path = os.path.dirname(os.path.abspath(os.path.expanduser(__file__)))
+    dll_path.append(curr_path)
+    #dll_path.append(os.path.join(curr_path,"../build"))
+    dll_path.append(os.path.join(curr_path,"lib"))
+    for path in os.environ.get('LD_LIBRARY_PATH', '').split(':'):
+        dll_path.append(path)
+        dll_path.append(os.path.join(path,"build"))
+        dll_path.append(os.path.join(path, "install/lib"))
+    path = [os.path.join(p,"libtengine-lite.so") for p in dll_path]
+    lib_path = [p for p in path if os.path.exists(p) and os.path.isfile(p)]
+    return lib_path
+
+def find_include_path():
+    """Find Tengine included header files.
+
+    Returns
+    -------
+    incl_path : string
+        Path to the header files.
+    """
+    curr_path = os.path.dirname(os.path.abspath(os.path.expanduser(__file__)))
+    # include path in pip package
+    pip_incl_path = os.path.join(curr_path, 'include/')
+    if os.path.isdir(pip_incl_path):
+        return pip_incl_path
+    else:
+        # include path if build from source
+        src_incl_path = os.path.join(curr_path, '../../include/')
+        if os.path.isdir(src_incl_path):
+            return src_incl_path
+        else:
+            raise RuntimeError('Cannot find the Tengine include path in either ' + pip_incl_path +
+                               ' or ' + src_incl_path + '\n')
+
+
+# current version
+__version__ = "0.1.0"

--- a/pytengine/tengine/node.py
+++ b/pytengine/tengine/node.py
@@ -1,0 +1,200 @@
+# coding: utf-8
+"""Information about Tengine."""
+import ctypes
+from .base import _LIB,  c_str, node_t, tensor_t, check_call
+from .tensor import Tensor
+from .base import tensor_dump_header
+
+
+class Node(object):
+    def __init__(self, graph = None,name=None,op=None,node=None):
+        """
+        Create a node object for the graph.
+        :param graph: <graph object>
+        :param name: <str> node_name: The name of the node.
+        :param op: <str> op_name: The name of the operate.
+        :param node: <node pointer>
+        """
+        if node:
+            self.node = node
+        else:
+            _LIB.create_graph_node.restype = node_t
+            self.node = _LIB.create_graph_node(ctypes.c_void_p(graph.graph), c_str(name), c_str(op))
+        self._attr = {}
+        pass
+
+    def __del__(self):
+        """
+        release this node
+        :return: None
+        """
+        if self.node:
+            _LIB.release_graph_node(ctypes.c_void_p(self.node))
+        self.node = None
+
+    @property
+    def __name__(self):
+        """
+        Get the node name.
+        :return: The node name, None on error.
+        """
+        _LIB.get_node_name.restype = ctypes.c_char_p
+        return _LIB.get_node_name(ctypes.c_void_p(self.node))
+
+    @property
+    def __op__(self):
+        """
+        Get the node op.
+        :return: The op name, None on error.
+        """
+        _LIB.get_node_op.restype = ctypes.c_char_p
+        return _LIB.get_node_op(ctypes.c_void_p(self.node))
+
+    def getInputTensorByIdx(self, idx):
+        """
+        Get the input tensor handle of a node.
+        :param idx: <int> The index of the input tensor.
+        :return: The tensor name or None on error
+        """
+        _LIB.get_node_input_tensor.restype = tensor_t
+        tensor =  _LIB.get_node_input_tensor(ctypes.c_void_p(self.node), idx)
+        return Tensor(tensor=tensor)
+
+    def getOutputTensorByIdx(self, idx):
+        """
+        Get the output tensor handle of a node.
+        :param idx: <int> The index of the output tensor.
+        :return: The tensor handle or None on error.
+        """
+        _LIB.get_node_output_tensor.restype = tensor_t
+        tensor = _LIB.get_node_output_tensor(ctypes.c_void_p(self.node), idx)
+        return Tensor(tensor = tensor)
+
+    def setInputTensorByIdx(self, idx, tensor):
+        """
+        Set a node's the idx input tensor.
+        :param idx: <int> The index of the input tensor.
+        :param tensor: <tensor object>
+        :return: None
+        """
+        check_call(_LIB.set_node_input_tensor(ctypes.c_void_p(self.node), idx, ctypes.c_void_p(tensor.tensor)))
+
+    def setOutputTensorByIdx(self, idx, tensor, type):
+        """
+        Set a node's the #idx output tensor.
+        :param idx: <int> tensor index of the output tensor
+        :param tensor: <tensor object>
+        :param type: <tensor_type> like: tg.TENSOR_TYPE_UNKNOWN,tg.TENSOR_TYPE_VAR etc.
+        :return:None
+        """
+        check_call(_LIB.set_node_output_tensor(ctypes.c_void_p(self.node), idx, ctypes.c_void_p(tensor.tensor), type))
+
+    def getOutputNumber(self):
+        """
+        Get the output tensor number of a node.
+        :return: <int> >=1: the number of output tensor, -1: error
+        """
+        return _LIB.get_node_output_number(ctypes.c_void_p(self.node))
+
+    def getInputNumber(self):
+        """
+        Get the input tensor number of a node.
+        :return: <int> >=1: the number of output tensor, -1: error
+        """
+        return _LIB.get_node_input_number(ctypes.c_void_p(self.node))
+
+    def setAttr(self, attr_name, attr):
+        """
+        set the attribute value of a node
+        Note: if the attribute is not existed, add first.
+        :param attr_name: <str> attribute name
+        :param attr: <int> or <float>
+        :return: None
+        """
+        if type(attr) is int:
+            data = ctypes.c_int(0)
+            self._attr[attr_name] = ctypes.c_int
+            ret = _LIB.get_node_attr_int(ctypes.c_void_p(self.node), c_str(attr_name), ctypes.pointer(data))
+            if ret < 0:
+                _LIB.add_node_attr(ctypes.c_void_p(self.node),c_str(attr_name),c_str("int"),ctypes.sizeof(ctypes.c_int))
+            _LIB.set_node_attr_int(ctypes.c_void_p(self.node),c_str(attr_name),ctypes.pointer(ctypes.c_int(attr)))
+        elif type(attr) is float:
+            self._attr[attr_name] = ctypes.c_float
+            data = ctypes.c_float(0.0)
+            ret = _LIB.get_node_attr_float(ctypes.c_void_p(self.node), c_str(attr_name), ctypes.pointer(data))
+            if ret < 0:
+                _LIB.add_node_attr(ctypes.c_void_p(self.node), c_str(attr_name), c_str("float"),
+                                   ctypes.sizeof(ctypes.c_int))
+            _LIB.set_node_attr_float(ctypes.c_void_p(self.node), c_str(attr_name), ctypes.pointer(ctypes.c_float(attr)))
+
+
+    def getAttr(self,attr,type=None):
+        """
+        Get the attribute value (float or int) of a node
+        :param attr: <str> The name of the attribute to be retrieval.
+        :param type: like: "int" or "float"
+        :return: <int> or <float>
+        """
+        if (self._attr.has_key(attr) and self._attr[attr] is ctypes.c_int) or type is int:
+            data = ctypes.c_int(0)
+            _LIB.get_node_attr_int(ctypes.c_void_p(self.node),c_str(attr),ctypes.pointer(data))
+            return data.value
+        elif (self._attr.has_key(attr) and self._attr[attr] is ctypes.c_float) or type is float:
+            data = ctypes.c_float(0.0)
+            _LIB.get_node_attr_float(ctypes.c_void_p(self.node),c_str(attr),ctypes.pointer(data))
+            return data.value
+
+    def setKernel(self, dev_name, kernel_ops):
+        """
+        Set customer kernel of a node, on a specific device
+        Note: the operate in kernel_ops must be the same as node's operate.
+        :param dev_name: <str>
+        :param kernel_ops: <custom_kernel_ops object>
+        :return: None
+        """
+        check_call(_LIB.set_custom_kernel(ctypes.c_void_p(self.node), c_str(dev_name), ctypes.byref(kernel_ops)))
+
+    def removeKernel(self, dev_name):
+        """
+        Remove customer kernel of a node, on a specific device.
+        :param dev_name:<str>  The kernel works for which device. None means for default device.
+        :return: None
+        """
+        check_call(_LIB.remove_custom_kernel(ctypes.c_void_p(self.node), c_str(dev_name)))
+
+    def setDevice(self, dev_name):
+        """
+        Set the device to execution a node.
+        :param dev_name: <str> The device name to run the node.
+        :return: None
+        """
+        check_call(_LIB.set_node_device(ctypes.c_void_p(self.node), c_str(dev_name)))
+
+    def getDevice(self):
+        """
+        get the device the node runs on
+        :return: <str> or None
+        """
+        _LIB.get_node_device.restype = ctypes.c_char_p
+        return _LIB.get_node_device(ctypes.c_void_p(self.node))
+
+    def dump(self, action):
+        """
+        Enable dump function pre-defined on device on a node,
+        Note: the dump buffer will be returned by getDumpBuf
+        :param action: 1: enable, 0: disable
+        :return: None
+        """
+        check_call(_LIB.do_node_dump(ctypes.c_void_p(self.node), action))
+
+    def getDumpBuf(self, size):
+        """
+        Get the dump buffer pointer generated by target device
+        exact meaning of the dump buffer is decided by device.
+        :param size: <int> the pointer array size
+        :return: <list> buf list
+        """
+        buf = (ctypes.POINTER(tensor_dump_header) * size)()
+        ret = _LIB.get_node_dump_buffer(ctypes.c_void_p(self.node), ctypes.byref(buf), size)
+        return buf[:ret]
+

--- a/pytengine/tengine/tengine.py
+++ b/pytengine/tengine/tengine.py
@@ -1,0 +1,224 @@
+# coding: utf-8
+"""Information about Tengine."""
+import ctypes
+from .base import _LIB
+from .base import check_call, c_str, log_print_t, cpu_info
+from .graph import Graph
+from .context import Context
+from .node import Node
+from .tensor import Tensor
+from .device import Device
+import os
+
+class Tengine(object):
+    """initialize the tengine"""
+
+    def __init__(self):
+        """
+        Initialize the tengine, only can be called once.
+        """
+        check_call(_LIB.init_tengine())
+        self.log_lever = property(None, self.__log_lever)
+        self.log_print = property(None, self.__log_output)
+        self.plugin = self.Plugin()
+
+    def __del__(self):
+        """
+        Release the tengine, only can be called once.
+        :return: None
+        """
+        _LIB.release_tengine()
+
+    @property
+    def __errno__(self):
+        """
+        return the error number
+        list of the symbolic error name follows glibc definitions
+        :return: <int> error number
+        """
+        return _LIB.get_tengine_errno()
+
+    @property
+    def __version__(self):
+        """
+        Get the version of the tengine.
+        :return: <str>
+        """
+        _LIB.get_tengine_version.restype = ctypes.c_char_p
+        return _LIB.get_tengine_version()
+
+    def requestTengineVersion(self, version):
+        """
+        Check the run-time library supports the verson.
+        :param version: <str> version: A c string returned by tg.__version__
+        :return: 1: support, 0: not support
+        """
+        return _LIB.request_tengine_version(c_str(version))
+
+    def setDefaultDevice(self,dev_name):
+        """
+        set The default device.
+        :param dev_name: <str> The device name.
+        :return: None
+        """
+        check_call(_LIB.set_default_device(c_str(dev_name)))
+
+    def __log_lever(self, value):
+        """
+        Set the logger level.
+        :param value: <log_level> The log level. like: tg.LOG_EMERG, tg.LOG_ALERT, etc.
+        :return: None
+        """
+        self.log_level = value
+        _LIB.set_log_level(ctypes.c_int(value))
+
+    def __log_output(self, func):
+        """
+        set the print function of log.
+        :param func: python function like: def function(str): ...
+        :return: None
+        """
+        _LIB.set_log_output(log_print_t(func))
+
+    def get_predefined_cpu(self,name):
+        _LIB.get_predefined_cpu.restype = ctypes.POINTER(cpu_info)
+        return _LIB.get_predefined_cpu(c_str(name))[0]
+
+    def set_online_cpu(self,cpu_info,cpu_list):
+        cpu_list = (ctypes.c_int * len(cpu_list))(*cpu_list)
+        return _LIB.set_online_cpu(ctypes.byref(cpu_info), ctypes.byref(cpu_list), len(cpu_list))
+
+    def create_cpu_device(self,name,cpu_info):
+        return _LIB.create_cpu_device(c_str(name), ctypes.byref(cpu_info))
+
+    class Plugin(object):
+        def __init__(self):
+            self.pluginList = []
+            pass
+
+        def add(self, name, fname, init_func):
+            """
+            Load one plugin from disk, and execute the init function.
+            :param name:  <str> plugin_name: Plugin name.
+            :param fname: <str> fname: Plugin file name.
+            :param init_func: The name of the init function.
+            :return: None
+            """
+            self.pluginList.append(name)
+            check_call(_LIB.load_tengine_plugin(c_str(name), c_str(fname), c_str(init_func)))
+
+        def remove(self, name, del_func):
+            """
+            Unload one plugin and call the release function.
+            :param name: <str> plugin_name: The name of plugin.
+            :param del_func: <str> rel_func_name: The release function name.
+            :return: None
+            """
+            self.pluginList.remove(name)
+            check_call(_LIB.unload_tengine_plugin(c_str(name), c_str(del_func)))
+
+        def __len__(self):
+            """
+            Get the number of loaded plugin.
+            :return: <int> The plugin number.
+            """
+            return _LIB.get_tengine_plugin_number()
+
+        def __getitem__(self, item):
+            """
+            Get the name of idx plugin.
+            :param item: <int> The index of loaded plugin.
+            :return: The name of plugin.
+            """
+            if type(item) is int:
+                _LIB.get_tengine_plugin_name.restype = ctypes.c_char_p
+                return _LIB.get_tengine_plugin_name(item)
+            else:
+                return None
+
+
+tg = Tengine()
+tg.Graph = Graph
+tg.Context = Context
+tg.Node = Node
+tg.Tensor = Tensor
+tg.Device = Device
+
+
+# /* the data type of the tensor */
+(tg.TENGINE_DT_FP32,
+  tg.TENGINE_DT_FP16,
+  tg.TENGINE_DT_INT8,
+  tg.TENGINE_DT_UINT8,
+  tg.TENGINE_DT_INT32,
+  tg.TENGINE_DT_INT16) = map(int,range(6))
+
+
+# /* layout type, not real layout */
+(tg.TENGINE_LAYOUT_NCHW,
+ tg.TENGINE_LAYOUT_NHWC) = map(int, range(2))
+
+# /* tensor type: the content changed or not during inference */
+(tg.TENSOR_TYPE_UNKNOWN,
+ tg.TENSOR_TYPE_VAR,
+ tg.TENSOR_TYPE_CONST,
+ tg.TENSOR_TYPE_INPUT,
+ tg.TENSOR_TYPE_DEP) = map(int, range(5))
+
+# /* node dump action definition */
+(tg.NODE_DUMP_ACTION_DISABLE,
+ tg.NODE_DUMP_ACTION_ENABLE,
+ tg.NODE_DUMP_ACTION_START,
+ tg.NODE_DUMP_ACTION_STOP,
+ tg.NODE_DUMP_ACTION_GET) = map(int, range(5))
+
+# /* graph perf action definition */
+(tg.GRAPH_PERF_STAT_DISABLE,
+ tg.GRAPH_PERF_STAT_ENABLE,
+ tg.GRAPH_PERF_STAT_STOP,
+ tg.GRAPH_PERF_STAT_START,
+ tg.GRAPH_PERF_STAT_RESET,
+ tg.GRAPH_PERF_STAT_GET) = map(int, range(6))
+
+# /* quant mode */
+(tg.TENGINE_QUANT_FP16,
+ tg.TENGINE_QUANT_INT8,
+ tg.TENGINE_QUANT_UINT8) = map(int, range(3))
+
+# /*follow the std. UNIX log level definitioin */
+(tg.LOG_EMERG,
+ tg.LOG_ALERT,
+ tg.LOG_CRIT,
+ tg.LOG_ERR,
+ tg.LOG_WARNING,
+ tg.LOG_NOTICE,
+ tg.LOG_INFO,
+ tg.LOG_DEBUG
+) = map(int,range(8))
+
+# * todo: should add suspend? */
+(
+    tg.GRAPH_STAT_CREATED,
+    tg.GRAPH_STAT_READY,
+    tg.GRAPH_STAT_RUNNING,
+    tg.GRAPH_STAT_DONE,
+    tg.GRAPH_STAT_ERROR
+) = map(int,range(5))
+
+# /* graph_exec_event */
+(
+    tg.GRAPH_EXEC_START,
+    tg.GRAPH_EXEC_SUSPEND,
+    tg.GRAPH_EXEC_RESUME,
+    tg.GRAPH_EXEC_ABORT,
+    tg.GRAPH_EXEC_DONE
+) = map(int,range(5))
+
+# /* device_policy */
+(
+    tg.DEFAULT_POLICY,
+    tg.LATENCY_POLICY,
+    tg.LOW_POWER_POLICY
+) = map(int,range(3))
+
+

--- a/pytengine/tengine/tensor.py
+++ b/pytengine/tengine/tensor.py
@@ -1,0 +1,232 @@
+# coding: utf-8
+"""Information about Tengine."""
+
+import ctypes
+from .base import _LIB, c_str, tensor_t, ctypes2numpy_shared, ctypes2buffer, DType, check_call, Tengine_ctype
+import numpy as np
+import time
+
+class Tensor(object):
+    def __init__(self, graph=None, name=None, type=None,tensor=None):
+        """
+        create a tensor object by tensor name or by tensor pointer
+        :param graph: <graph object>
+        :param name: <str> tensor name
+        :param type: <data_type> : the data type
+        :param tensor: <tensor pointer> normal used by the sys
+        """
+        if tensor:
+            self.tensor = tensor
+        else:
+            _LIB.create_graph_tensor.restype = tensor_t
+            self.tensor = _LIB.create_graph_tensor(ctypes.c_void_p(graph.graph), c_str(name), type)
+        self._data = None
+        self.shape_number = None
+        self.length = 4
+        pass
+
+    def __del__(self):
+        """
+        release the tensor object
+        :return: None
+        """
+        if self.tensor:
+            _LIB.release_graph_tensor(ctypes.c_void_p(self.tensor))
+        self.tensor = None
+
+    @property
+    def __name__(self):
+        """
+        get the name of the tensor object
+        :return: <str> name of the tensor object
+        """
+        _LIB.get_tensor_name.restype = ctypes.c_char_p
+        return _LIB.get_tensor_name(ctypes.c_void_p(self.tensor))
+
+    def __len__(self):
+        """
+        get the byte size of a tensor should occupy
+        :return: <int> 0: the shape of the tensor is not set yet.
+        """
+        return _LIB.get_tensor_buffer_size(ctypes.c_void_p(self.tensor))
+
+    @property
+    def shape(self):
+        """
+        get the shape of tensor
+        :return: <list> An int array
+        """
+        dim = (ctypes.c_int * self.length)(0, 0, 0, 0)
+        _LIB.get_tensor_shape.restype = ctypes.c_int
+        self.shape_number = _LIB.get_tensor_shape(ctypes.c_void_p(self.tensor), ctypes.cast(dim, ctypes.POINTER(ctypes.c_int)), 4)
+        return ctypes2numpy_shared(ctypes.cast(dim, ctypes.POINTER(ctypes.c_int)), (1, 4))[0]
+
+    @property
+    def shape_num(self):
+        """
+        valid dim number
+        :return: >=1 the dim number, -1: fail
+        """
+        return self.shape_number
+
+    @shape.setter
+    def shape(self, dims):
+        """
+        set the shape of tensor
+        :param dims: <list> An int array to represent shape
+        :return: None
+        """
+        self.length = len(dims)
+        c_dims = (ctypes.c_int * self.length)(*dims)
+        check_call(_LIB.set_tensor_shape(ctypes.c_void_p(self.tensor), ctypes.cast(c_dims, ctypes.POINTER(ctypes.c_int)), self.length))
+
+    def getbuffer(self, type=int):
+        """
+        Get the byte size of a tensor should occupy.
+        :param type: <type> int or float
+        :return:
+        """
+        if type is int:
+            _LIB.get_tensor_buffer.restype = ctypes.POINTER(ctypes.c_int)
+        elif type is float:
+            _LIB.get_tensor_buffer.restype = ctypes.POINTER(ctypes.c_float)
+        elif type is str:
+            _LIB.get_tensor_buffer.restype = ctypes.POINTER(ctypes.c_char)
+        else:
+            return None
+        return _LIB.get_tensor_buffer(ctypes.c_void_p(self.tensor))
+
+    @property
+    def buf(self):
+        """
+        Get the byte size of a tensor should occupy. only for buf that user set themselves
+        :return: <list> data list
+        """
+        dtype = self.dtype
+        ctype = Tengine_ctype[dtype.enum]
+        size = len(self) // ctypes.sizeof(ctype)
+        if ctype is ctypes.c_char:
+            _LIB.get_tensor_buffer.restype = ctypes.POINTER(ctype)
+            res = _LIB.get_tensor_buffer(ctypes.c_void_p(self.tensor))
+            return res[:size]
+        _LIB.get_tensor_buffer.restype = ctypes.POINTER(ctype)
+        res = _LIB.get_tensor_buffer(ctypes.c_void_p(self.tensor))
+        return res[:size]
+
+    @buf.setter
+    def buf(self, value):
+        """
+        Set the buffer of the tensor.
+        :param value: <int list> or <float list> or <str list>
+        :return: None
+        """
+        _LIB.set_tensor_buffer.argtypes = [ctypes.c_void_p, ctypes.c_void_p, ctypes.c_int]
+        check_call(_LIB.set_tensor_buffer(self.tensor, np.ctypeslib.as_ctypes(value), value.size * ctypes.sizeof((ctypes.c_float))))
+
+    def getData(self):
+        """
+        get tensor data.
+        :return: <list>
+        """
+        if self._data[0] == ctypes.c_int:
+            c_data = (ctypes.c_int * self._data[1])(0)
+            check_call(_LIB.get_tensor_data(ctypes.c_void_p(self.tensor), ctypes.pointer(c_data), ctypes.sizeof(ctypes.c_int)))
+            return ctypes2numpy_shared(ctypes.cast(c_data, ctypes.POINTER(ctypes.c_int)), (1, self._data[1]))
+        elif self._data[0] == ctypes.c_float:
+            c_data = (ctypes.c_float * self._data[1])(0.0)
+            check_call(_LIB.get_tensor_data(ctypes.c_void_p(self.tensor), ctypes.cast(c_data, ctypes.c_char_p),
+                                 ctypes.sizeof(ctypes.c_float)))
+            return c_data[:self._data[1]]
+        elif self._data[0] == ctypes.c_char:
+            c_data = ctypes.create_string_buffer("", self._data[1])
+            check_call(_LIB.get_tensor_data(ctypes.c_void_p(self.tensor), ctypes.cast(c_data, ctypes.c_void_p),
+                                 ctypes.sizeof(ctypes.c_char) * self._data[1]))
+            return ctypes2buffer(ctypes.cast(c_data, ctypes.POINTER(ctypes.c_char)), self._data[1])
+        else:
+            return None
+
+    def setData(self, data):
+        """
+        Copy the data to tensor buffer.
+        :param data: <int> or <float> or <str> or <list>  the input data
+        :return: None
+        """
+        if type(data) == type(0):
+            self._data = [ctypes.c_int, 1]
+            c_data = (ctypes.c_int * 1)(data)
+            check_call(_LIB.set_tensor_data(ctypes.c_void_p(self.tensor), ctypes.cast(c_data, ctypes.POINTER(ctypes.c_int)),
+                                        ctypes.sizeof(ctypes.c_int)))
+        elif type(data) == type(0.1):
+            self._data = [ctypes.c_float, 1]
+            c_data = (ctypes.c_float * 1)(data)
+            check_call(_LIB.set_tensor_data(ctypes.c_void_p(self.tensor),
+                                        ctypes.cast(c_data, ctypes.POINTER(ctypes.c_float)),
+                                        ctypes.sizeof(ctypes.c_float)))
+        elif type(data) == type("0"):
+            self._data = [ctypes.c_char, len(data)]
+            c_data = ctypes.create_string_buffer(data)
+            check_call(_LIB.set_tensor_data(ctypes.c_void_p(self.tensor), ctypes.cast(c_data, ctypes.c_char_p),
+                                        ctypes.sizeof(c_data)))
+        elif type(data) == type([]):
+            size = len(data)
+            if size:
+                if type(data[0]) == type(0):
+                    self._data = [ctypes.c_int, size]
+                    c_data = (ctypes.c_int * size)(data)
+                    check_call(_LIB.set_tensor_data(ctypes.c_void_p(self.tensor),
+                                                ctypes.cast(c_data, ctypes.POINTER(ctypes.c_int)),
+                                                ctypes.sizeof(ctypes.c_int) * size))
+                elif type(data[0]) == type(0.0):
+                    self._data = [ctypes.c_float, size]
+                    c_data = (ctypes.c_float * size)(data)
+                    check_call(_LIB.set_tensor_data(ctypes.c_void_p(self.tensor),
+                                                ctypes.cast(c_data, ctypes.POINTER(ctypes.c_float)),
+                                                ctypes.sizeof(ctypes.c_float) * size))
+                else:
+                    return -1
+            else:
+                return -1
+        else:
+            return -1
+
+    @property
+    def dtype(self):
+        """
+        Get the data type of the tensor.
+        :return: <The tensor type> like: TENGINE_DT_FP32 etc, -1 on error.
+        """
+        d =  _LIB.get_tensor_data_type(ctypes.c_void_p(self.tensor))
+        return DType(d)
+
+    @dtype.setter
+    def dtype(self, type):
+        """
+        Get the data type of the tensor.
+        :param type:
+        :return: None
+        """
+        check_call(_LIB.set_tensor_data_type(ctypes.c_void_p(self.tensor), type))
+
+    def setQuantParam(self, scale, zero_point, number):
+        """
+        Set tensor quant parameters
+        :param scale: <float list> the scale list
+        :param zero_point: <int> the zero point address
+        :param number: <int> the element number of array
+        :return: None
+        """
+        _LIB.set_tensor_quant_param.argtypes = [ctypes.c_void_p,ctypes.POINTER(ctypes.c_float),ctypes.POINTER(ctypes.c_int),ctypes.c_int]
+        check_call(_LIB.set_tensor_quant_param(ctypes.c_void_p(self.tensor), np.ctypeslib.as_ctypes(scale),
+                                           np.ctypeslib.as_ctypes(zero_point), number))
+
+    def getQuantParam(self, number):
+        """
+        Get tensor quant parameters.
+        :param number: <int> the element number of array
+        :return: (<scale list>,<zero_point list>)
+        """
+        scale = ctypes.c_float * number
+        zero_point = ctypes.c_int * number
+        _LIB.get_tensor_quant_param(ctypes.c_void_p(self.tensor), ctypes.POINTER(scale), ctypes.POINTER(zero_point),
+                                    number)
+        return scale[:number], zero_point[:number]


### PR DESCRIPTION
Hi there, the pytengine has been added into tengine-lite and I provides an example.

Firstly, we can move these files (cat.jpg, mobilenet.tmfile and synset_words.txt) into the directory examples.
```
# Tengine-lite/examples/classification.py
➜  examples git:(add_pytengine) ✗ tree
.
├── cat.jpg
├── classification.py
├── mobilenet.tmfile
├── synset_words.txt
```

Here are the arguments of classification.py:
```
➜  examples git:(add_pytengine) ✗ python classification.py -h
usage: classification.py [-h] [-m MODEL] [-i IMAGE] [-g IMAGE_SIZE] [-w MEAN_VALUE] [-s SCALE] [-l LABEL]

classification

optional arguments:
  -h, --help            show this help message and exit
  -m MODEL, --model MODEL
  -i IMAGE, --image IMAGE
  -g IMAGE_SIZE, --image-size IMAGE_SIZE
                        image size: height, width
  -w MEAN_VALUE, --mean-value MEAN_VALUE
                        mean value: mean1, mean2, mean3
  -s SCALE, --scale SCALE
  -l LABEL, --label LABEL
                        the default path of labels.txt (e.g. synset_words.txt)
```

Execute classification.py
```
➜  examples git:(add_pytengine) ✗ python classification.py 
n02123159 tiger cat 8.597596168518066
n02119022 red fox, Vulpes vulpes 7.954998970031738
n02119789 kit fox, Vulpes macrotis 7.867897987365723
n02113023 Pembroke, Pembroke Welsh corgi 7.427414417266846
n02123045 tabby, tabby cat 6.364652633666992
```