### PR TITLE
添加pooling的sse实现

### DIFF
--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -22,6 +22,7 @@ tengine_example(tm_yolov3_uint8             tm_yolov3_uint8.cpp)
 tengine_example(tm_landmark                 tm_landmark.cpp)
 tengine_example(tm_landmark_uint8           tm_landmark_uint8.cpp)
 tengine_example(tm_mobilefacenet            tm_mobilefacenet.cpp)
+tengine_example(tm_yolov4                   tm_yolov4.cpp)
 
 
 # add examples with opencv

--- a/examples/tm_yolov4.cpp
+++ b/examples/tm_yolov4.cpp
@@ -185,7 +185,7 @@ std::vector<detection*> forward_darknet_layer_cpu(const float* input, layer l, i
                 {
                     int grid_index = entry_index(l, i, j, loc);
                     logistic_cpu(l.output + grid_index, 1);
-                    temp_detection->prob[j - 5] = l.output[grid_index > s_thresh] ? l.output[grid_index] : 0;
+                    temp_detection->prob[j - 5] = l.output[grid_index] > s_thresh ? l.output[grid_index] : 0;
                 }
 
                 /* classes_num */

--- a/examples/tm_yolov4.cpp
+++ b/examples/tm_yolov4.cpp
@@ -1,0 +1,516 @@
+#include <stdio.h>
+
+#include <unistd.h>
+#include <stdlib.h>
+#include <stdio.h>
+#include <vector>
+#include <algorithm>
+
+#include "common.h"
+#include "tengine_c_api.h"
+#include "tengine_operations.h"
+
+#define YOLOV4_NUM_BOXES 3
+#define YOLOV4_TOTAL_ANCHOR 9
+#define CLASSES_COCO 80
+
+const float s_thresh = 0.5;
+const float s_hier_thresh = 0.5;
+const float s_nms = 0.45;
+
+float s_anchors[] = {12, 16, 19, 36, 40, 28, 36, 75, 76, 55, 72, 146, 142, 110, 192, 243, 459, 401};
+
+typedef struct layer
+{
+    int total_anchor;
+    int box, c, h, w;
+    int out_n, out_c, out_h, out_w;
+    int classes;
+    int inputs;
+    int outputs;
+    int* anchor_mask;
+    float* anchors;
+    float* output;
+    int coords;
+} layer;
+
+typedef struct
+{
+    float x, y, w, h;
+} box;
+
+typedef struct
+{
+    box bbox;
+    float x, y, w, h;
+    int classes;
+    float* prob;
+    float objectness;
+    int sort_class;
+} detection;
+
+layer make_darknet_layer(int w, int h, int net_w, int net_h, int n, int total, int classes)
+{
+    layer l = {0};
+    l.box = n;
+    l.total_anchor = total;
+    l.h = h;
+    l.w = w;
+    l.c = n * (classes + 4 + 1);
+    l.out_w = l.w;
+    l.out_h = l.h;
+    l.out_c = l.c;
+    l.classes = classes;
+    l.inputs = l.w * l.h * l.c;
+
+    l.anchors = ( float* )calloc(total * 2, sizeof(float));
+    l.anchor_mask = ( int* )calloc(n, sizeof(int));
+    if (9 == total)
+    {
+        for (int i = 0; i < total * 2; ++i)
+        {
+            l.anchors[i] = s_anchors[i];
+        }
+        if (l.w == net_w / 32)
+        {
+            int j = 6;
+            for (int i = 0; i < l.box; ++i)
+                l.anchor_mask[i] = j++;
+        }
+        if (l.w == net_w / 16)
+        {
+            int j = 3;
+            for (int i = 0; i < l.box; ++i)
+                l.anchor_mask[i] = j++;
+        }
+        if (l.w == net_w / 8)
+        {
+            int j = 0;
+            for (int i = 0; i < l.box; ++i)
+                l.anchor_mask[i] = j++;
+        }
+    }
+    l.outputs = l.inputs;
+    l.output = ( float* )calloc(l.outputs, sizeof(float));
+
+    return l;
+}
+
+int entry_index(layer l, int box, int channel, int loc)
+{
+    return box * l.w * l.h * (4 + l.classes + 1) + channel * l.w * l.h + loc;
+}
+
+inline void logistic_cpu(float* input, int size)
+{
+    for (int i = 0; i < size; ++i)
+    {
+        input[i] = 1.f / (1.f + expf(-input[i]));
+    }
+}
+
+inline float logistic_cpu(float input)
+{
+    return 1.f / (1.f + expf(-input));
+}
+
+void decodebox(layer l, box& b, int box_index, int row, int col, int input_w, int input_h)
+{
+    b.x = (col + logistic_cpu(b.x)) / l.w;
+    b.y = (row + logistic_cpu(b.y)) / l.h;
+    b.w = exp(b.w) * l.anchors[2 * l.anchor_mask[box_index]] / input_w;
+    b.h = exp(b.h) * l.anchors[2 * l.anchor_mask[box_index] + 1] / input_h;
+}
+
+void correct_yolo_boxes(std::vector<detection*>& dets, int n, int w, int h, int netw, int neth)
+{
+    int i;
+    int new_w = 0;
+    int new_h = 0;
+    if ((( float )netw / w) < (( float )neth / h))
+    {
+        new_w = netw;
+        new_h = (h * netw) / w;
+    }
+    else
+    {
+        new_h = neth;
+        new_w = (w * neth) / h;
+    }
+    for (i = 0; i < n; ++i)
+    {
+        box b = dets[i]->bbox;
+        b.x = (b.x - (netw - new_w) / 2. / netw) / (( float )new_w / netw);
+        b.y = (b.y - (neth - new_h) / 2. / neth) / (( float )new_h / neth);
+        b.w *= ( float )netw / new_w;
+        b.h *= ( float )neth / new_h;
+
+        dets[i]->bbox = b;
+    }
+}
+
+std::vector<detection*> forward_darknet_layer_cpu(const float* input, layer l, int img_w, int img_h, int net_w,
+                                                  int net_h)
+{
+    std::vector<detection*> dets;
+    memcpy(( void* )l.output, ( void* )input, sizeof(float) * l.inputs);
+
+    for (int i = 0; i < l.box; i++)
+    {
+        int index = entry_index(l, i, 4, 0);
+        logistic_cpu(l.output + index, l.w * l.h);
+        for (size_t loc = 0; loc < l.w * l.h; loc++)
+        {
+            if (l.output[index + loc] > s_thresh)
+            {
+                /* row col */
+                int row = loc / l.w;
+                int col = loc % l.w;
+
+                detection* temp_detection = ( detection* )calloc(1, sizeof(detection));
+
+                /* objectness */
+                temp_detection->objectness = l.output[index + loc];
+
+                /* bbox */
+                temp_detection->bbox.x = l.output[entry_index(l, i, 0, loc)];
+                temp_detection->bbox.y = l.output[entry_index(l, i, 1, loc)];
+                temp_detection->bbox.w = l.output[entry_index(l, i, 2, loc)];
+                temp_detection->bbox.h = l.output[entry_index(l, i, 3, loc)];
+                decodebox(l, temp_detection->bbox, i, row, col, net_w, net_h);
+
+                /* classes_prob */
+                temp_detection->prob = ( float* )calloc(l.classes, sizeof(float));
+                for (int j = 5; j < l.classes + 5; j++)
+                {
+                    int grid_index = entry_index(l, i, j, loc);
+                    logistic_cpu(l.output + grid_index, 1);
+                    temp_detection->prob[j - 5] = l.output[grid_index > s_thresh] ? l.output[grid_index] : 0;
+                }
+
+                /* classes_num */
+                temp_detection->classes = l.classes;
+
+                dets.push_back(temp_detection);
+            }
+        }
+    }
+
+    if (dets.size() > 0)
+    {
+        correct_yolo_boxes(dets, dets.size(), img_w, img_h, net_w, net_h);
+    }
+
+    return dets;
+}
+
+int nms_comparator(const detection* pa, const detection* pb)
+{
+    float diff = 0;
+    if (pb->sort_class >= 0)
+    {
+        diff = pb->prob[pb->sort_class] - pb->prob[pb->sort_class];
+    }
+    else
+    {
+        diff = pb->objectness - pb->objectness;
+    }
+    if (diff < 0)
+        return -1;
+    else if (diff > 0)
+        return 1;
+    return 0;
+}
+
+float overlap(float x1, float w1, float x2, float w2)
+{
+    float l1 = x1 - w1 / 2;
+    float l2 = x2 - w2 / 2;
+    float left = l1 > l2 ? l1 : l2;
+    float r1 = x1 + w1 / 2;
+    float r2 = x2 + w2 / 2;
+    float right = r1 < r2 ? r1 : r2;
+    return right - left;
+}
+
+float box_intersection(box a, box b)
+{
+    float w = overlap(a.x, a.w, b.x, b.w);
+    float h = overlap(a.y, a.h, b.y, b.h);
+    if (w < 0 || h < 0)
+        return 0;
+    float area = w * h;
+    return area;
+}
+
+float box_union(box a, box b)
+{
+    float i = box_intersection(a, b);
+    float u = a.w * a.h + b.w * b.h - i;
+    return u;
+}
+
+float box_iou(box a, box b)
+{
+    return box_intersection(a, b) / box_union(a, b);
+}
+
+void do_nms_sort(std::vector<detection*>& dets, int total, int classes, float thresh)
+{
+    int i, j, k;
+    k = total - 1;
+    for (i = 0; i <= k; ++i)
+    {
+        if (dets[i]->objectness == 0)
+        {
+            detection* swap = dets[i];
+            dets[i] = dets[k];
+            dets[k] = swap;
+            --k;
+            --i;
+        }
+    }
+    total = k + 1;
+
+    for (k = 0; k < classes; ++k)
+    {
+        for (i = 0; i < total; ++i)
+        {
+            dets[i]->sort_class = k;
+        }
+        std::sort(dets.begin(), dets.end(), nms_comparator);
+        for (i = 0; i < total; ++i)
+        {
+            if (dets[i]->prob[k] == 0)
+                continue;
+            box a = dets[i]->bbox;
+            for (j = i + 1; j < total; ++j)
+            {
+                box b = dets[j]->bbox;
+                if (box_iou(a, b) > thresh)
+                {
+                    dets[j]->prob[k] = 0;
+                }
+            }
+        }
+    }
+}
+
+void get_input_data_darknet(const char* image_file, float* input_data, int net_h, int net_w)
+{
+    int size = 3 * net_w * net_h;
+    image sized;
+    image im = load_image_stb(image_file, 3);
+    for (int i = 0; i < im.c * im.h * im.w; i++)
+    {
+        im.data[i] = im.data[i] / 255;
+    }
+    sized = letterbox(im, net_w, net_h);
+    memcpy(input_data, sized.data, size * sizeof(float));
+
+    free_image(sized);
+    free_image(im);
+}
+
+void show_usage()
+{
+    fprintf(
+        stderr,
+        "[Usage]:  [-h]\n    [-m model_file] [-i image_file] [-r repeat_count] [-t thread_count] [-s size:608:512] \n");
+}
+
+int main(int argc, char* argv[])
+{
+    const char* model_file = nullptr;
+    const char* image_file = nullptr;
+    int net_h = 608;
+    int net_w = 608;
+    int repeat_count = 1;
+    int num_thread = 1;
+
+    int res;
+    while ((res = getopt(argc, argv, "m:i:r:t:h:s:")) != -1)
+    {
+        switch (res)
+        {
+            case 'm':
+                model_file = optarg;
+                break;
+            case 'i':
+                image_file = optarg;
+                break;
+            case 'r':
+                repeat_count = std::strtoul(optarg, nullptr, 10);
+                break;
+            case 't':
+                num_thread = std::strtoul(optarg, nullptr, 10);
+                break;
+            case 's':
+                net_w = std::strtoul(optarg, nullptr, 10);
+                net_h = net_w;
+                fprintf(stderr, "set net input size: %d %d\n", net_h, net_w);
+                break;
+            case 'h':
+                show_usage();
+                return 0;
+            default:
+                break;
+        }
+    }
+
+    /* check files */
+    if (nullptr == model_file)
+    {
+        fprintf(stderr, "Error: Tengine model file not specified!\n");
+        show_usage();
+        return -1;
+    }
+
+    if (nullptr == image_file)
+    {
+        fprintf(stderr, "Error: Image file not specified!\n");
+        show_usage();
+        return -1;
+    }
+
+    if (!check_file_exist(model_file) || !check_file_exist(image_file))
+        return -1;
+
+    /* init */
+    init_tengine();
+    fprintf(stderr, "tengine-lite library version: %s\n", get_tengine_version());
+
+    /* create graph, load tengine model xxx.tmfile */
+    graph_t graph = create_graph(nullptr, "tengine", model_file);
+    if (graph == nullptr)
+    {
+        fprintf(stderr, "Create graph failed.\n");
+        fprintf(stderr, "errno: %d \n", get_tengine_errno());
+        return -1;
+    }
+
+    /* set the input shape to initial the graph, and prerun graph to infer shape */
+    int img_size = net_h * net_w * 3;
+    int dims[] = {1, 3, net_h, net_w};    // nchw
+
+    std::vector<float> input_data(img_size);
+
+    tensor_t input_tensor = get_graph_input_tensor(graph, 0, 0);
+    if (input_tensor == nullptr)
+    {
+        fprintf(stderr, "Get input tensor failed\n");
+        return -1;
+    }
+
+    if (set_tensor_shape(input_tensor, dims, 4) < 0)
+    {
+        fprintf(stderr, "Set input tensor shape failed\n");
+        return -1;
+    }
+
+    if (prerun_graph(graph) < 0)
+    {
+        fprintf(stderr, "Prerun graph failed\n");
+        return -1;
+    }
+
+    /* prepare process input data, set the data mem to input tensor */
+    get_input_data_darknet(image_file, input_data.data(), net_h, net_w);
+    if (set_tensor_buffer(input_tensor, input_data.data(), img_size * 4) < 0)
+    {
+        fprintf(stderr, "Set input tensor buffer failed\n");
+        return -1;
+    }
+
+    /* run graph */
+    double min_time = __DBL_MAX__;
+    double max_time = -__DBL_MAX__;
+    double total_time = 0.;
+    for (int i = 0; i < 1; i++)
+    {
+        double start = get_current_time();
+        if (run_graph(graph, 1) < 0)
+        {
+            fprintf(stderr, "Run graph failed\n");
+            return -1;
+        }
+        double end = get_current_time();
+        double cur = end - start;
+        total_time += cur;
+        min_time = std::min(min_time, cur);
+        max_time = std::max(max_time, cur);
+    }
+    fprintf(stderr, "Repeat %d times, thread %d, avg time %.2f ms, max_time %.2f ms, min_time %.2f ms\n", 1, 1,
+            total_time, max_time, min_time);
+    fprintf(stderr, "--------------------------------------\n");
+
+    image img = imread(image_file);
+    int output_node_num = get_graph_output_node_number(graph);
+
+    /* save layer */
+    std::vector<layer> layers_params;
+    layers_params.clear();
+
+    /* save detection reslult */
+    std::vector<detection*> detections;
+    detections.clear();
+
+    /* decode layer one by one*/
+    for (int node = 0; node < output_node_num; ++node)
+    {
+        tensor_t out_tensor = get_graph_output_tensor(graph, node, 0);
+        int out_dim[4];
+        get_tensor_shape(out_tensor, out_dim, 4);
+        layer l_params;
+        int out_w = out_dim[3];
+        int out_h = out_dim[2];
+        l_params = make_darknet_layer(out_w, out_h, net_w, net_h, YOLOV4_NUM_BOXES, YOLOV4_TOTAL_ANCHOR, CLASSES_COCO);
+        layers_params.push_back(l_params);
+        float* out_data = ( float* )get_tensor_buffer(out_tensor);
+        std::vector<detection*> l_dets = forward_darknet_layer_cpu(out_data, l_params, img.w, img.h, net_w, net_h);
+        if (l_dets.size() == 0)
+            continue;
+        detections.insert(detections.end(), l_dets.begin(), l_dets.end());
+    }
+
+    if (detections.size() == 0)
+    {
+        fprintf(stderr, "no object detect");
+        return 0;
+    }
+
+    /* do nms */
+    do_nms_sort(detections, detections.size(), CLASSES_COCO, s_nms);
+
+    /* print output dectections */
+    int i, j;
+    for (i = 0; i < detections.size(); ++i)
+    {
+        int cls = -1;
+        for (j = 0; j < CLASSES_COCO; ++j)
+        {
+            if (detections[i]->prob[j] > 0.5)
+            {
+                if (cls < 0)
+                {
+                    cls = j;
+                }
+                fprintf(stderr, "%d: %.0f%%\n", cls, detections[i]->prob[j] * 100);
+            }
+        }
+        if (cls >= 0)
+        {
+            box b = detections[i]->bbox;
+            int left = (b.x - b.w / 2.) * img.w;
+            int right = (b.x + b.w / 2.) * img.w;
+            int top = (b.y - b.h / 2.) * img.h;
+            int bot = (b.y + b.h / 2.) * img.h;
+            draw_box(img, left, top, right, bot, 2, 125, 0, 125);
+            fprintf(stderr, "left = %d,right = %d,top = %d,bot = %d\n", left, right, top, bot);
+        }
+    }
+
+    save_image(img, "tengine_example_out");
+
+    return 0;
+}

--- a/examples/tm_yolov4.cpp
+++ b/examples/tm_yolov4.cpp
@@ -508,9 +508,38 @@ int main(int argc, char* argv[])
             draw_box(img, left, top, right, bot, 2, 125, 0, 125);
             fprintf(stderr, "left = %d,right = %d,top = %d,bot = %d\n", left, right, top, bot);
         }
+
+        if (detections[i]->prob)
+            free(detections[i]->prob);
     }
 
     save_image(img, "tengine_example_out");
+
+    /* free resource */
+    /* release tengine */
+    for (int i = 0; i < output_node_num; ++i)
+    {
+        tensor_t out_tensor = get_graph_output_tensor(graph, i, 0);
+        release_graph_tensor(out_tensor);
+    }
+
+    free_image(img);
+
+    for (int i = 0; i < layers_params.size(); i++)
+    {
+        layer l = layers_params[i];
+        if (l.output)
+            free(l.output);
+        if (l.anchors)
+            free(l.anchors);
+        if (l.anchor_mask)
+            free(l.anchor_mask);
+    }
+
+    release_graph_tensor(input_tensor);
+    postrun_graph(graph);
+    destroy_graph(graph);
+    release_tengine();
 
     return 0;
 }

--- a/src/dev/cpu/op/pooling/pooling_sse_x86.c
+++ b/src/dev/cpu/op/pooling/pooling_sse_x86.c
@@ -1,0 +1,170 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * License); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * AS IS BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+/*
+ * Copyright (c) 2020, OPEN AI LAB
+ * Author: 1091545398@qq.com
+ */
+
+#include "sys_port.h"
+#include "module.h"
+#include "tengine_ir.h"
+#include "../../cpu_node_ops.h"
+#include "tengine_op.h"
+#include "pooling_param.h"
+#include "pooling_sse_x86.h"
+
+#define POOL_K2S2 1
+#define POOL_K3S2 2
+#define POOL_K3S1 3
+
+static int prerun(struct node_ops* node_ops, struct exec_node* exec_node, struct exec_graph* exec_graph)
+{
+    struct ir_node* ir_node = exec_node->ir_node;
+    struct ir_graph* ir_graph = ir_node->graph;
+    struct ir_tensor* input_tensor;
+    struct ir_tensor* output_tensor;
+
+    struct pool_param* pool_param = ( struct pool_param* )ir_node->op.param_mem;
+
+    input_tensor = get_ir_graph_tensor(ir_graph, ir_node->input_tensors[0]);
+    output_tensor = get_ir_graph_tensor(ir_graph, ir_node->output_tensors[0]);
+
+    pooling_kernel_perf_prerun(input_tensor, output_tensor, pool_param);
+
+    return 0;
+}
+
+static int run(struct node_ops* node_ops, struct exec_node* exec_node, struct exec_graph* exec_graph)
+{
+    struct ir_node* ir_node = exec_node->ir_node;
+    struct ir_graph* ir_graph = ir_node->graph;
+    struct ir_tensor* input_tensor;
+    struct ir_tensor* output_tensor;
+
+    struct pool_param* pool_param = ( struct pool_param* )ir_node->op.param_mem;
+
+    input_tensor = get_ir_graph_tensor(ir_graph, ir_node->input_tensors[0]);
+    output_tensor = get_ir_graph_tensor(ir_graph, ir_node->output_tensors[0]);
+
+    pooling_kernel_perf_run(input_tensor, output_tensor, pool_param, exec_graph->num_thread);
+
+    return 0;
+}
+
+static int postrun(struct node_ops* node_ops, struct exec_node* exec_node, struct exec_graph* exec_graph)
+{
+    return 0;
+}
+
+static int init_node(struct node_ops* node_ops, struct exec_node* exec_node, struct exec_graph* dev)
+{
+    return 0;
+}
+
+static int release_node(struct node_ops* node_ops, struct exec_node* exec_node, struct exec_graph* dev)
+{
+    return 0;
+}
+
+static int score(struct node_ops* node_ops, struct exec_graph* exec_graph, struct ir_node* exec_node)
+{
+    struct pool_param* pool_param = ( struct pool_param* )exec_node->op.param_mem;
+
+    int global = pool_param->global;
+    int type = pool_param->pool_method;
+    int kernel_h = pool_param->kernel_h;
+    int kernel_w = pool_param->kernel_w;
+    int stride_h = pool_param->stride_h;
+    int stride_w = pool_param->stride_w;
+    int pad_h0 = pool_param->pad_h0;
+    int pad_h1 = pool_param->pad_h1;
+    int pad_w0 = pool_param->pad_w0;
+    int pad_w1 = pool_param->pad_w1;
+    int pad_tf = pool_param->pad_h0_org;    // maybe there is a bug.
+
+    int pool_size = 0;
+
+    struct ir_node* ir_node = exec_node;
+    struct ir_graph* ir_graph = ir_node->graph;
+    struct ir_tensor* input_tensor = get_ir_graph_tensor(ir_graph, ir_node->input_tensors[0]);
+
+    /* todo support uint8 */
+    if (input_tensor->data_type != TENGINE_DT_FP32)
+        return 0;
+
+    /* filter perf global pooling case */
+    if (global)
+        return OPS_SCORE_BEST;
+    /* filter perf general pooling case */
+    else
+    {
+        if (stride_h == 2 && stride_w == 2)
+        {
+            if (kernel_h == 2 && kernel_w == 2)
+                pool_size = POOL_K2S2;
+            if (kernel_h == 3 && kernel_w == 3)
+                pool_size = POOL_K3S2;
+        }
+
+        if (stride_h == 1 && stride_w == 1 && kernel_h == 3 && kernel_w == 3)
+            pool_size = POOL_K3S1;
+
+        /* general max pooling, k2s2, k2k2p1, k3s1p1, k3s2, k3s2p1 */
+        if (type == POOL_MAX && (pad_h0 == pad_w0) && (pad_h1 == pad_w1) && pad_tf != -1)
+        {
+            if (pad_h0 == 0 && (pool_size == POOL_K2S2 || pool_size == POOL_K3S2))
+                return OPS_SCORE_BEST;
+            if (pad_h0 == 1 && (pool_size == POOL_K2S2 || pool_size == POOL_K3S2 || pool_size == POOL_K3S1))
+                return OPS_SCORE_BEST;
+        }
+
+        /* general avg pooling, k2s2, k2s2p1, k3s2, k3s2p1 */
+        if (type == POOL_AVG && (pad_h0 == pad_w0) && (pad_h1 == pad_w1))
+        {
+            if (pad_h0 == 0 && pad_h1 == 0 && (pool_size == POOL_K2S2 || pool_size == POOL_K3S2))
+                return OPS_SCORE_BEST;
+            if (pad_h0 == 1 && pad_h1 == 1 && (pool_size == POOL_K2S2 || pool_size == POOL_K3S2))
+                return OPS_SCORE_BEST;
+        }
+    }
+
+    return 0;
+}
+
+static struct node_ops hcl_node_ops = {.prerun = prerun,
+                                       .run = run,
+                                       .reshape = NULL,
+                                       .postrun = postrun,
+                                       .init_node = init_node,
+                                       .release_node = release_node,
+                                       .score = score};
+
+static int reg_pooling_hcl_ops(void* arg)
+{
+    return register_builtin_node_ops(OP_POOL, &hcl_node_ops);
+}
+
+static int unreg_pooling_hcl_ops(void* arg)
+{
+    return unregister_builtin_node_ops(OP_POOL, &hcl_node_ops);
+}
+
+AUTO_REGISTER_OPS(reg_pooling_hcl_ops);
+AUTO_UNREGISTER_OPS(unreg_pooling_hcl_ops);

--- a/src/dev/cpu/op/pooling/pooling_sse_x86.h
+++ b/src/dev/cpu/op/pooling/pooling_sse_x86.h
@@ -1,0 +1,1821 @@
+#include <emmintrin.h>
+#include <stdio.h>
+#include <assert.h>
+#include "pooling_param.h"
+
+#define POOL_GENERIC 0
+#define POOL_K2S2 1
+#define POOL_K3S2 2
+#define POOL_K3S1 3
+
+typedef void (*pooling_kernel_t)(const void* input, void* output, int inc, int inh, int inw, int outh, int outw, int,
+                                 int, int, int, int, int, int pad_h1, int pad_w1, int);
+
+static inline float max(float a, float b)
+{
+    if (a > b)
+        return a;
+    else
+        return b;
+}
+
+static void max_3x3s1_p1(const float* input, float* output, int inc, int inh, int inw, int outh, int outw, int k_h,
+                         int k_w, int s_h, int s_w, int pad_h0, int pad_w0, int pad_h1, int pad_w1, int is_caffe)
+{
+    //     fprintf(stderr, "max_3x3s1_p1\n");
+    int in_hw = inw * inh;
+
+    int mid_w = inw - 2;
+    int mid_h = inh - 2;
+
+    for (int c = 0; c < inc; c++)
+    {
+        const float* line1 = input + c * in_hw;
+        const float* line2 = line1 + inw;
+
+        float* out_ptr = output + c * in_hw;
+
+        // h begin left----[line1+=0]-----------------------------------
+        *out_ptr = max(max(line1[0], line1[1]), max(line2[0], line2[1]));
+        out_ptr++;
+
+        // h begin center----[line1+=1]----------------------------------
+        for (int j = 0; j < mid_w; j++)
+        {
+            float max1 = max(max(line1[0], line1[1]), line1[2]);
+            float max2 = max(max(line2[0], line2[1]), line2[2]);
+            *out_ptr = max(max2, max1);
+            out_ptr++;
+            line1 += 1;
+            line2 += 1;
+        }
+        // h begin right----[line1+=2]-----------------------------------
+        *out_ptr = max(max(line1[0], line1[1]), max(line2[0], line2[1]));
+        out_ptr++;
+        line1 += 2;
+        line2 += 2;
+
+        // h center ---------------------------------------
+        const float* line0 = input + c * in_hw;
+
+        for (int i = 0; i < mid_h; i++)
+        {
+            // left
+            float max0 = max(max(line1[0], line1[1]), max(line2[0], line2[1]));
+            *out_ptr = max(max(line0[0], line0[1]), max0);
+            out_ptr++;
+
+            // mid
+            int j = 0;
+            for (; j + 4 < mid_w; j += 2)
+            {
+                __m128 r0 = _mm_loadu_ps(line0);
+                __m128 r1 = _mm_loadu_ps(line1);
+                __m128 r2 = _mm_loadu_ps(line2);
+
+                __m128 max0 = _mm_max_ps(_mm_max_ps(r0, r1), r2);
+
+                *out_ptr = max(max(max0[0], max0[1]), max0[2]);
+                out_ptr++;
+                *out_ptr = max(max(max0[1], max0[2]), max0[3]);
+                out_ptr++;
+                line0 += 2;
+                line1 += 2;
+                line2 += 2;
+            }
+
+            for (; j < mid_w; j++)
+            {
+                float max0 = max(max(line0[0], line0[1]), line0[2]);
+                float max1 = max(max(line1[0], line1[1]), line1[2]);
+                float max2 = max(max(line2[0], line2[1]), line2[2]);
+                *out_ptr = max(max(max0, max1), max2);
+                out_ptr++;
+                line0 += 1;
+                line1 += 1;
+                line2 += 1;
+            }
+
+            max0 = max(max(line1[0], line1[1]), max(line2[0], line2[1]));
+            *out_ptr = max(max(line0[0], line0[1]), max0);
+            out_ptr++;
+            line0 += 2;
+            line1 += 2;
+            line2 += 2;
+        }
+
+        // h end ------------------------------------------
+        *out_ptr = max(max(line1[0], line1[1]), max(line0[0], line0[1]));
+        out_ptr++;
+
+        for (int j = 0; j < mid_w; j++)
+        {
+            float max0 = max(max(line0[0], line0[1]), line0[2]);
+            float max1 = max(max(line1[0], line1[1]), line1[2]);
+
+            *out_ptr = max(max0, max1);
+            out_ptr++;
+            line0 += 1;
+            line1 += 1;
+        }
+
+        *out_ptr = max(max(line1[0], line1[1]), max(line0[0], line0[1]));
+    }
+}
+
+static void avg_2x2s2_p1(const float* input, float* output, int inc, int inh, int inw, int outh, int outw, int k_h,
+                         int k_w, int s_h, int s_w, int pad_h0, int pad_w0, int pad_h1, int pad_w1, int is_caffe)
+{
+    int in_hw = inw * inh;
+    int out_hw = outh * outw;
+
+    if (inw % 2 == 0)
+        outw--;
+    if (inh % 2 == 0)
+        outh--;
+    int block_w = (outw - 1) >> 2;
+    int remain_w = inw - outw * 2 + 1;
+
+    const __m128 scalar_025 = _mm_set1_ps(0.25);
+    const __m128 scalar_05 = _mm_set1_ps(0.5);
+
+    for (int c = 0; c < inc; c++)
+    {
+        const float* line00 = input + c * in_hw;
+        float* out_ptr = output + c * out_hw;
+        // h begin
+        if (is_caffe == 0)
+            *out_ptr = line00[0];
+        else
+            *out_ptr = line00[0] * 0.25;
+
+        out_ptr++;
+        line00++;
+        for (int j = 0; j < block_w; j++)
+        {
+            __m128 p00 = _mm_loadu_ps(line00);
+            __m128 p01 = _mm_loadu_ps(line00 + 4);
+
+            __m128 r00 = _mm_shuffle_ps(p00, p01, _MM_SHUFFLE(2, 0, 2, 0));
+            __m128 r01 = _mm_shuffle_ps(p00, p01, _MM_SHUFFLE(3, 1, 3, 1));
+
+            __m128 _sum = _mm_add_ps(r00, r01);
+
+            if (is_caffe == 0)
+                _sum = _mm_mul_ps(_sum, scalar_05);
+            else
+                _sum = _mm_mul_ps(_sum, scalar_025);
+            _mm_storeu_ps(out_ptr, _sum);
+
+            out_ptr += 4;
+            line00 += 8;
+        }
+        for (int j = block_w * 4 + 1; j < outw; j++)
+        {
+            if (is_caffe == 0)
+                *out_ptr = (line00[0] + line00[1]) * 0.5f;
+            else
+                *out_ptr = (line00[0] + line00[1]) * 0.25f;
+            out_ptr++;
+            line00 += 2;
+        }
+        if (inw % 2 == 0)
+        {
+            if (is_caffe == 0)
+                *out_ptr = line00[0];
+            else
+                *out_ptr = line00[0] * 0.25f;
+            out_ptr++;
+        }
+        line00 += remain_w;
+
+        // h center
+        const float* line0 = line00;
+        const float* line1 = line0 + inw;
+        for (int i = 1; i < outh; i++)
+        {
+            // w begin
+            if (is_caffe == 0)
+                *out_ptr = (line0[0] + line1[0]) * 0.25;
+            else
+                *out_ptr = (line0[0] + line1[0]) * 0.25;
+            out_ptr++;
+            line0++;
+            line1++;
+            // w center
+            for (int j = 0; j < block_w; j++)
+            {
+                __m128 p00 = _mm_loadu_ps(line0);
+                __m128 p01 = _mm_loadu_ps(line0 + 4);
+                __m128 p10 = _mm_loadu_ps(line1);
+                __m128 p11 = _mm_loadu_ps(line1 + 4);
+
+                __m128 r00 = _mm_shuffle_ps(p00, p01, _MM_SHUFFLE(2, 0, 2, 0));
+                __m128 r01 = _mm_shuffle_ps(p00, p01, _MM_SHUFFLE(3, 1, 3, 1));
+                __m128 r10 = _mm_shuffle_ps(p10, p11, _MM_SHUFFLE(2, 0, 2, 0));
+                __m128 r11 = _mm_shuffle_ps(p10, p11, _MM_SHUFFLE(3, 1, 3, 1));
+
+                __m128 sum0 = _mm_add_ps(r00, r01);
+                __m128 sum1 = _mm_add_ps(r10, r11);
+                __m128 _sum = _mm_add_ps(sum0, sum1);
+
+                _mm_storeu_ps(out_ptr, _mm_mul_ps(_sum, scalar_025));
+
+                out_ptr += 4;
+                line0 += 8;
+                line1 += 8;
+            }
+            for (int j = block_w * 4 + 1; j < outw; j++)
+            {
+                *out_ptr = (line0[0] + line0[1] + line1[0] + line1[1]) * 0.25;
+                out_ptr++;
+                line0 += 2;
+                line1 += 2;
+            }
+            // w end
+            if (inw % 2 == 0)
+            {
+                if (is_caffe == 0)
+                    *out_ptr = (line0[0] + line1[0]) * 0.5;
+                else
+                    *out_ptr = (line0[0] + line1[0]) * 0.25;
+                out_ptr++;
+            }
+            line0 += remain_w + inw;
+            line1 += remain_w + inw;
+        }
+        // h end
+        if (inh % 2 == 0)
+        {
+            if (is_caffe == 0)
+                *out_ptr = line0[0];
+            else
+                *out_ptr = line0[0] * 0.25;
+            out_ptr++;
+            line0++;
+            for (int j = 0; j < block_w; j++)
+            {
+                __m128 p00 = _mm_loadu_ps(line0);
+                __m128 p01 = _mm_loadu_ps(line0 + 4);
+
+                __m128 r00 = _mm_shuffle_ps(p00, p01, _MM_SHUFFLE(2, 0, 2, 0));
+                __m128 r01 = _mm_shuffle_ps(p00, p01, _MM_SHUFFLE(3, 1, 3, 1));
+
+                __m128 _sum = _mm_add_ps(r00, r01);
+                if (is_caffe == 0)
+                    _mm_storeu_ps(out_ptr, _mm_mul_ps(_sum, scalar_05));
+                else
+                    _mm_storeu_ps(out_ptr, _mm_mul_ps(_sum, scalar_025));
+                out_ptr += 4;
+                line0 += 8;
+            }
+            for (int j = block_w * 4 + 1; j < outw; j++)
+            {
+                if (is_caffe == 0)
+                    *out_ptr = (line0[0] + line0[1]) * 0.5;
+                else
+                    *out_ptr = (line0[0] + line0[1]) * 0.25;
+                out_ptr++;
+                line0 += 2;
+            }
+            if (inw % 2 == 0)
+            {
+                if (is_caffe == 0)
+                    *out_ptr = line0[0];
+                else
+                    *out_ptr = line0[0] * 0.25;
+            }
+        }
+    }
+}
+
+static void max_2x2s2_p1(const float* input, float* output, int inc, int inh, int inw, int outh, int outw, int k_h,
+                         int k_w, int s_h, int s_w, int pad_h0, int pad_w0, int pad_h1, int pad_w1, int is_caffe)
+{
+    int in_hw = inw * inh;
+    int out_hw = outh * outw;
+
+    if (inw % 2 == 0)
+        outw--;
+    if (inh % 2 == 0)
+        outh--;
+    int block_w = (outw - 1) >> 2;
+    int remain_w = inw - outw * 2 + 1;
+
+    for (int c = 0; c < inc; c++)
+    {
+        const float* line00 = input + c * in_hw;
+        float* out_ptr = output + c * out_hw;
+        // h begin
+        *out_ptr = line00[0];
+        out_ptr++;
+        line00++;
+        for (int j = 0; j < block_w; j++)
+        {
+            __m128 p00 = _mm_loadu_ps(line00);
+            __m128 p01 = _mm_loadu_ps(line00 + 4);
+
+            __m128 r00 = _mm_shuffle_ps(p00, p01, _MM_SHUFFLE(2, 0, 2, 0));
+            __m128 r01 = _mm_shuffle_ps(p00, p01, _MM_SHUFFLE(3, 1, 3, 1));
+
+            __m128 _max = _mm_max_ps(r00, r01);
+            _mm_storeu_ps(out_ptr, _max);
+
+            out_ptr += 4;
+            line00 += 8;
+        }
+        for (int j = block_w * 4 + 1; j < outw; j++)
+        {
+            *out_ptr = max(line00[0], line00[1]);
+            out_ptr++;
+            line00 += 2;
+        }
+        if (inw % 2 == 0)
+        {
+            *out_ptr = line00[0];
+            out_ptr++;
+        }
+        line00 += remain_w;
+
+        // h center
+        const float* line0 = line00;
+        const float* line1 = line0 + inw;
+        for (int i = 1; i < outh; i++)
+        {
+            // w begin
+            *out_ptr = max(line0[0], line1[0]);
+            out_ptr++;
+            line0++;
+            line1++;
+            // w center
+            for (int j = 0; j < block_w; j++)
+            {
+                __m128 p00 = _mm_loadu_ps(line0);
+                __m128 p01 = _mm_loadu_ps(line0 + 4);
+                __m128 p10 = _mm_loadu_ps(line1);
+                __m128 p11 = _mm_loadu_ps(line1 + 4);
+
+                __m128 r00 = _mm_shuffle_ps(p00, p01, _MM_SHUFFLE(2, 0, 2, 0));
+                __m128 r01 = _mm_shuffle_ps(p00, p01, _MM_SHUFFLE(3, 1, 3, 1));
+                __m128 r10 = _mm_shuffle_ps(p10, p11, _MM_SHUFFLE(2, 0, 2, 0));
+                __m128 r11 = _mm_shuffle_ps(p10, p11, _MM_SHUFFLE(3, 1, 3, 1));
+
+                __m128 max0 = _mm_max_ps(r00, r01);
+                __m128 max1 = _mm_max_ps(r10, r11);
+                __m128 _max = _mm_max_ps(max0, max1);
+
+                _mm_storeu_ps(out_ptr, _max);
+
+                out_ptr += 4;
+                line0 += 8;
+                line1 += 8;
+            }
+            for (int j = block_w * 4 + 1; j < outw; j++)
+            {
+                float l0max = max(line0[0], line0[1]);
+                float l1max = max(line1[0], line1[1]);
+                *out_ptr = max(l0max, l1max);
+                out_ptr++;
+                line0 += 2;
+                line1 += 2;
+            }
+            // w end
+            if (inw % 2 == 0)
+            {
+                *out_ptr = max(line0[0], line1[0]);
+                out_ptr++;
+            }
+            line0 += remain_w + inw;
+            line1 += remain_w + inw;
+        }
+        // h end
+        if (inh % 2 == 0)
+        {
+            *out_ptr = line0[0];
+            out_ptr++;
+            line0++;
+            for (int j = 0; j < block_w; j++)
+            {
+                __m128 p00 = _mm_loadu_ps(line0);
+                __m128 p01 = _mm_loadu_ps(line0 + 4);
+
+                __m128 r00 = _mm_shuffle_ps(p00, p01, _MM_SHUFFLE(2, 0, 2, 0));
+                __m128 r01 = _mm_shuffle_ps(p00, p01, _MM_SHUFFLE(3, 1, 3, 1));
+
+                __m128 _max = _mm_max_ps(r00, r01);
+                _mm_storeu_ps(out_ptr, _max);
+
+                out_ptr += 4;
+                line0 += 8;
+            }
+            for (int j = block_w * 4 + 1; j < outw; j++)
+            {
+                *out_ptr = max(line0[0], line0[1]);
+                out_ptr++;
+                line0 += 2;
+            }
+            if (inw % 2 == 0)
+            {
+                *out_ptr = line0[0];
+            }
+        }
+    }
+}
+
+static void max_3x3s2_p1(const float* input, float* output, int inc, int inh, int inw, int outh, int outw, int k_h,
+                         int k_w, int s_h, int s_w, int pad_h0, int pad_w0, int pad_h1, int pad_w1, int is_caffe)
+
+{
+    // fprintf(stderr, "max_3x3s2_p1\n");
+    int in_hw = inw * inh;
+    int out_hw = outh * outw;
+
+    if (is_caffe == 1 || inw % 2 == 1)
+        outw--;
+    if (is_caffe == 1 || inh % 2 == 1)
+        outh--;
+    int block_w = (outw - 1) >> 2;
+    int remain_w = inw - outw * 2 + 1;
+
+    for (int c = 0; c < inc; c++)
+    {
+        const float* line1 = input + c * in_hw;
+        const float* line2 = line1 + inw;
+        float* out_ptr = output + c * out_hw;
+
+        // h begin ---------------------------------------
+        *out_ptr = max(max(line1[0], line1[1]), max(line2[0], line2[1]));
+        out_ptr++;
+        line1 += 1;
+        line2 += 1;
+
+        for (int j = 0; j < block_w; j++)
+        {
+            __m128 p10 = _mm_loadu_ps(line1);
+            __m128 p11 = _mm_loadu_ps(line1 + 1);
+            __m128 p12 = _mm_loadu_ps(line1 + 2);
+
+            __m128 p14 = _mm_loadu_ps(line1 + 4);
+            __m128 p15 = _mm_loadu_ps(line1 + 5);
+            __m128 p16 = _mm_loadu_ps(line1 + 6);
+
+            __m128 max102 = _mm_max_ps(p10, p11);
+            max102 = _mm_max_ps(max102, p12);
+            __m128 max146 = _mm_max_ps(p14, p15);
+            max146 = _mm_max_ps(max146, p16);
+
+            __m128 max1 = _mm_shuffle_ps(max102, max146, _MM_SHUFFLE(2, 0, 2, 0));
+
+            __m128 p20 = _mm_loadu_ps(line2);
+            __m128 p21 = _mm_loadu_ps(line2 + 1);
+            __m128 p22 = _mm_loadu_ps(line2 + 2);
+
+            __m128 p24 = _mm_loadu_ps(line2 + 4);
+            __m128 p25 = _mm_loadu_ps(line2 + 5);
+            __m128 p26 = _mm_loadu_ps(line2 + 6);
+
+            __m128 max202 = _mm_max_ps(p20, p21);
+            max202 = _mm_max_ps(max202, p22);
+            __m128 max246 = _mm_max_ps(p24, p25);
+            max246 = _mm_max_ps(max246, p26);
+
+            __m128 max2 = _mm_shuffle_ps(max202, max246, _MM_SHUFFLE(2, 0, 2, 0));
+
+            _mm_storeu_ps(out_ptr, _mm_max_ps(max2, max1));
+
+            line1 += 8;
+            line2 += 8;
+            out_ptr += 4;
+        }
+        for (int j = block_w * 4 + 1; j < outw; j++)
+        {
+            float max1 = max(max(line1[0], line1[1]), line1[2]);
+            float max2 = max(max(line2[0], line2[1]), line2[2]);
+            *out_ptr = max(max1, max2);
+
+            out_ptr++;
+            line1 += 2;
+            line2 += 2;
+        }
+        if (inw % 2 == 1)
+        {
+            *out_ptr = max(max(line1[0], line1[1]), max(line2[0], line2[1]));
+            out_ptr++;
+        }
+        else if (is_caffe == 1 && inw % 2 == 0)
+        {
+            *out_ptr = max(line1[0], line2[0]);
+            out_ptr++;
+        }
+        line1 += remain_w;
+        line2 += remain_w;
+
+        // h center ---------------------------------------
+        const float* line0 = line1;
+        line1 = line2;
+        line2 = line1 + inw;
+        for (int i = 1; i < outh; i++)
+        {
+            // left
+            float max0 = max(max(line1[0], line1[1]), max(line2[0], line2[1]));
+            *out_ptr = max(max(line0[0], line0[1]), max0);
+            out_ptr++;
+            line0 += 1;
+            line1 += 1;
+            line2 += 1;
+            // mid
+            for (int j = 0; j < block_w; j++)
+            {
+                __m128 p00 = _mm_loadu_ps(line0);
+                __m128 p01 = _mm_loadu_ps(line0 + 1);
+                __m128 p02 = _mm_loadu_ps(line0 + 2);
+
+                __m128 p04 = _mm_loadu_ps(line0 + 4);
+                __m128 p05 = _mm_loadu_ps(line0 + 5);
+                __m128 p06 = _mm_loadu_ps(line0 + 6);
+
+                __m128 max002 = _mm_max_ps(p00, p01);
+                max002 = _mm_max_ps(max002, p02);
+                __m128 max046 = _mm_max_ps(p04, p05);
+                max046 = _mm_max_ps(max046, p06);
+
+                __m128 max0 = _mm_shuffle_ps(max002, max046, _MM_SHUFFLE(2, 0, 2, 0));
+
+                __m128 p10 = _mm_loadu_ps(line1);
+                __m128 p11 = _mm_loadu_ps(line1 + 1);
+                __m128 p12 = _mm_loadu_ps(line1 + 2);
+
+                __m128 p14 = _mm_loadu_ps(line1 + 4);
+                __m128 p15 = _mm_loadu_ps(line1 + 5);
+                __m128 p16 = _mm_loadu_ps(line1 + 6);
+
+                __m128 max102 = _mm_max_ps(p10, p11);
+                max102 = _mm_max_ps(max102, p12);
+                __m128 max146 = _mm_max_ps(p14, p15);
+                max146 = _mm_max_ps(max146, p16);
+
+                __m128 max1 = _mm_shuffle_ps(max102, max146, _MM_SHUFFLE(2, 0, 2, 0));
+
+                __m128 p20 = _mm_loadu_ps(line2);
+                __m128 p21 = _mm_loadu_ps(line2 + 1);
+                __m128 p22 = _mm_loadu_ps(line2 + 2);
+
+                __m128 p24 = _mm_loadu_ps(line2 + 4);
+                __m128 p25 = _mm_loadu_ps(line2 + 5);
+                __m128 p26 = _mm_loadu_ps(line2 + 6);
+
+                __m128 max202 = _mm_max_ps(p20, p21);
+                max202 = _mm_max_ps(max202, p22);
+                __m128 max246 = _mm_max_ps(p24, p25);
+                max246 = _mm_max_ps(max246, p26);
+
+                __m128 max2 = _mm_shuffle_ps(max202, max246, _MM_SHUFFLE(2, 0, 2, 0));
+
+                __m128 max = _mm_max_ps(_mm_max_ps(max0, max1), max2);
+                _mm_storeu_ps(out_ptr, max);
+
+                line0 += 8;
+                line1 += 8;
+                line2 += 8;
+                out_ptr += 4;
+            }
+            for (int j = block_w * 4 + 1; j < outw; j++)
+            {
+                float max0 = max(max(line0[0], line0[1]), line0[2]);
+                float max1 = max(max(line1[0], line1[1]), line1[2]);
+                float max2 = max(max(line2[0], line2[1]), line2[2]);
+                *out_ptr = max(max(max0, max1), max2);
+
+                out_ptr++;
+                line0 += 2;
+                line1 += 2;
+                line2 += 2;
+            }
+            if (inw % 2 == 1)
+            {
+                max0 = max(max(line1[0], line1[1]), max(line2[0], line2[1]));
+                *out_ptr = max(max(line0[0], line0[1]), max0);
+                out_ptr++;
+            }
+            else if (inw % 2 == 0 && is_caffe == 1)
+            {
+                *out_ptr = max(max(line0[0], line1[0]), line2[0]);
+                out_ptr++;
+            }
+            line0 += inw + remain_w;
+            line1 += inw + remain_w;
+            line2 += inw + remain_w;
+        }
+
+        // h end ------------------------------------------
+        if (inh % 2 == 1)
+        {
+            *out_ptr = max(max(line1[0], line1[1]), max(line0[0], line0[1]));
+            out_ptr++;
+            line0 += 1;
+            line1 += 1;
+
+            for (int j = 0; j < block_w; j++)
+            {
+                __m128 p00 = _mm_loadu_ps(line0);
+                __m128 p01 = _mm_loadu_ps(line0 + 1);
+                __m128 p02 = _mm_loadu_ps(line0 + 2);
+
+                __m128 p04 = _mm_loadu_ps(line0 + 4);
+                __m128 p05 = _mm_loadu_ps(line0 + 5);
+                __m128 p06 = _mm_loadu_ps(line0 + 6);
+
+                __m128 max002 = _mm_max_ps(p00, p01);
+                max002 = _mm_max_ps(max002, p02);
+                __m128 max046 = _mm_max_ps(p04, p05);
+                max046 = _mm_max_ps(max046, p06);
+
+                __m128 max0 = _mm_shuffle_ps(max002, max046, _MM_SHUFFLE(2, 0, 2, 0));
+
+                __m128 p10 = _mm_loadu_ps(line1);
+                __m128 p11 = _mm_loadu_ps(line1 + 1);
+                __m128 p12 = _mm_loadu_ps(line1 + 2);
+
+                __m128 p14 = _mm_loadu_ps(line1 + 4);
+                __m128 p15 = _mm_loadu_ps(line1 + 5);
+                __m128 p16 = _mm_loadu_ps(line1 + 6);
+
+                __m128 max102 = _mm_max_ps(p10, p11);
+                max102 = _mm_max_ps(max102, p12);
+                __m128 max146 = _mm_max_ps(p14, p15);
+                max146 = _mm_max_ps(max146, p16);
+
+                __m128 max1 = _mm_shuffle_ps(max102, max146, _MM_SHUFFLE(2, 0, 2, 0));
+
+                _mm_storeu_ps(out_ptr, _mm_max_ps(max0, max1));
+
+                line0 += 8;
+                line1 += 8;
+                out_ptr += 4;
+            }
+            for (int j = block_w * 4 + 1; j < outw; j++)
+            {
+                float max0 = max(max(line0[0], line0[1]), line0[2]);
+                float max1 = max(max(line1[0], line1[1]), line1[2]);
+                *out_ptr = max(max0, max1);
+
+                out_ptr++;
+                line0 += 2;
+                line1 += 2;
+            }
+            if (inw % 2 == 1)
+            {
+                *out_ptr = max(max(line1[0], line1[1]), max(line0[0], line0[1]));
+                out_ptr++;
+            }
+            else if (inw % 2 == 0 && is_caffe == 1)
+            {
+                *out_ptr = max(line0[0], line1[0]);
+                out_ptr++;
+            }
+        }
+        else if (inh % 2 == 0 && is_caffe == 1)
+        {
+            *out_ptr = max(line0[0], line0[1]);
+            out_ptr++;
+            line0 += 1;
+
+            for (int j = 0; j < block_w; j++)
+            {
+                __m128 p00 = _mm_loadu_ps(line0);
+                __m128 p01 = _mm_loadu_ps(line0 + 1);
+                __m128 p02 = _mm_loadu_ps(line0 + 2);
+
+                __m128 p04 = _mm_loadu_ps(line0 + 4);
+                __m128 p05 = _mm_loadu_ps(line0 + 5);
+                __m128 p06 = _mm_loadu_ps(line0 + 6);
+
+                __m128 max002 = _mm_max_ps(p00, p01);
+                max002 = _mm_max_ps(max002, p02);
+                __m128 max046 = _mm_max_ps(p04, p05);
+                max046 = _mm_max_ps(max046, p06);
+
+                __m128 max0 = _mm_shuffle_ps(max002, max046, _MM_SHUFFLE(2, 0, 2, 0));
+
+                _mm_store_ps(out_ptr, max0);
+
+                line0 += 8;
+                out_ptr += 4;
+            }
+            for (int j = block_w * 4 + 1; j < outw; j++)
+            {
+                *out_ptr = max(max(line0[0], line0[1]), line0[2]);
+
+                out_ptr++;
+                line0 += 2;
+            }
+            if (inw % 2 == 1)
+            {
+                *out_ptr = max(line0[0], line0[1]);
+                out_ptr++;
+            }
+            else if (inw % 2 == 0)
+            {
+                *out_ptr = line0[0];
+            }
+        }
+    }
+}
+
+static void max_3x3s2(const float* input, float* output, int inc, int inh, int inw, int outh, int outw, int k_h,
+                      int k_w, int s_h, int s_w, int pad_h0, int pad_w0, int pad_h1, int pad_w1, int is_caffe)
+
+{
+    int in_hw = inw * inh;
+    int out_hw = outh * outw;
+
+    if (pad_w1 > 0)
+    {
+        outw--;
+    }
+    if (pad_h1 > 0)
+    {
+        outh--;
+    }
+    int block_w = outw >> 2;
+    int remain_w = inw - outw * 2;
+
+    for (int c = 0; c < inc; c++)
+    {
+        const float* line0 = input + c * in_hw;
+        const float* line1 = line0 + inw;
+        const float* line2 = line1 + inw;
+        float* out_ptr = output + c * out_hw;
+        for (int i = 0; i < outh; i++)
+        {
+            for (int j = 0; j < block_w; j++)
+            {
+                /*
+                p00     = [1,2,3,4,5,6,7,8]
+                p00.val[0]=[1,3,5,7]
+
+                max0    = [2,4,6,8]
+                p00_new = [9,10,11,12,13,14,15,16]
+                p01     = [3,5,7,9]
+                max0=max(max0,p01)=[3,5,7,9]
+                */
+
+                __m128 p00 = _mm_loadu_ps(line0);
+                __m128 p01 = _mm_loadu_ps(line0 + 1);
+                __m128 p02 = _mm_loadu_ps(line0 + 2);
+
+                __m128 p04 = _mm_loadu_ps(line0 + 4);
+                __m128 p05 = _mm_loadu_ps(line0 + 5);
+                __m128 p06 = _mm_loadu_ps(line0 + 6);
+
+                __m128 max002 = _mm_max_ps(p00, p01);
+                max002 = _mm_max_ps(max002, p02);
+                __m128 max046 = _mm_max_ps(p04, p05);
+                max046 = _mm_max_ps(max046, p06);
+
+                __m128 max0 = _mm_shuffle_ps(max002, max046, _MM_SHUFFLE(2, 0, 2, 0));
+
+                __m128 p10 = _mm_loadu_ps(line1);
+                __m128 p11 = _mm_loadu_ps(line1 + 1);
+                __m128 p12 = _mm_loadu_ps(line1 + 2);
+
+                __m128 p14 = _mm_loadu_ps(line1 + 4);
+                __m128 p15 = _mm_loadu_ps(line1 + 5);
+                __m128 p16 = _mm_loadu_ps(line1 + 6);
+
+                __m128 max102 = _mm_max_ps(p10, p11);
+                max102 = _mm_max_ps(max102, p12);
+                __m128 max146 = _mm_max_ps(p14, p15);
+                max146 = _mm_max_ps(max146, p16);
+
+                __m128 max1 = _mm_shuffle_ps(max102, max146, _MM_SHUFFLE(2, 0, 2, 0));
+
+                __m128 p20 = _mm_loadu_ps(line2);
+                __m128 p21 = _mm_loadu_ps(line2 + 1);
+                __m128 p22 = _mm_loadu_ps(line2 + 2);
+
+                __m128 p24 = _mm_loadu_ps(line2 + 4);
+                __m128 p25 = _mm_loadu_ps(line2 + 5);
+                __m128 p26 = _mm_loadu_ps(line2 + 6);
+
+                __m128 max202 = _mm_max_ps(p20, p21);
+                max202 = _mm_max_ps(max202, p22);
+                __m128 max246 = _mm_max_ps(p24, p25);
+                max246 = _mm_max_ps(max246, p26);
+
+                __m128 max2 = _mm_shuffle_ps(max202, max246, _MM_SHUFFLE(2, 0, 2, 0));
+
+                __m128 max = _mm_max_ps(_mm_max_ps(max0, max1), max2);
+                _mm_storeu_ps(out_ptr, max);
+
+                line0 += 8;
+                line1 += 8;
+                line2 += 8;
+                out_ptr += 4;
+            }
+            for (int j = block_w * 4; j < outw; j++)
+            {
+                float max0 = max(max(line0[0], line0[1]), line0[2]);
+                float max1 = max(max(line1[0], line1[1]), line1[2]);
+                float max2 = max(max(line2[0], line2[1]), line2[2]);
+                *out_ptr = max(max(max0, max1), max2);
+
+                out_ptr++;
+                line0 += 2;
+                line1 += 2;
+                line2 += 2;
+            }
+            if (pad_w1 == 1)
+            {
+                float max0 = max(max(line0[0], line0[1]), max(line1[0], line1[1]));
+                *out_ptr = max(max(line2[0], line2[1]), max0);
+                out_ptr++;
+            }
+            line0 += remain_w + inw;
+            line1 += remain_w + inw;
+            line2 += remain_w + inw;
+        }
+        if (pad_h1 == 1)
+        {
+            for (int j = 0; j < block_w; j++)
+            {
+                __m128 p00 = _mm_loadu_ps(line0);
+                __m128 p01 = _mm_loadu_ps(line0 + 1);
+                __m128 p02 = _mm_loadu_ps(line0 + 2);
+
+                __m128 p04 = _mm_loadu_ps(line0 + 4);
+                __m128 p05 = _mm_loadu_ps(line0 + 5);
+                __m128 p06 = _mm_loadu_ps(line0 + 6);
+
+                __m128 max002 = _mm_max_ps(p00, p01);
+                max002 = _mm_max_ps(max002, p02);
+                __m128 max046 = _mm_max_ps(p04, p05);
+                max046 = _mm_max_ps(max046, p06);
+
+                __m128 max0 = _mm_shuffle_ps(max002, max046, _MM_SHUFFLE(2, 0, 2, 0));
+
+                __m128 p10 = _mm_loadu_ps(line1);
+                __m128 p11 = _mm_loadu_ps(line1 + 1);
+                __m128 p12 = _mm_loadu_ps(line1 + 2);
+
+                __m128 p14 = _mm_loadu_ps(line1 + 4);
+                __m128 p15 = _mm_loadu_ps(line1 + 5);
+                __m128 p16 = _mm_loadu_ps(line1 + 6);
+
+                __m128 max102 = _mm_max_ps(p10, p11);
+                max102 = _mm_max_ps(max102, p12);
+                __m128 max146 = _mm_max_ps(p14, p15);
+                max146 = _mm_max_ps(max146, p16);
+
+                __m128 max1 = _mm_shuffle_ps(max102, max146, _MM_SHUFFLE(2, 0, 2, 0));
+
+                _mm_storeu_ps(out_ptr, _mm_max_ps(max0, max1));
+
+                line0 += 8;
+                line1 += 8;
+                out_ptr += 4;
+            }
+            for (int j = block_w * 4; j < outw; j++)
+            {
+                float max0 = max(max(line0[0], line0[1]), line0[2]);
+                float max1 = max(max(line1[0], line1[1]), line1[2]);
+
+                *out_ptr = max(max0, max1);
+
+                out_ptr++;
+                line0 += 2;
+                line1 += 2;
+            }
+            if (pad_w1 == 1)
+            {
+                *out_ptr = max(max(line0[0], line0[1]), max(line1[0], line1[1]));
+                out_ptr++;
+            }
+        }
+    }
+}
+
+static void avg_2x2s2(const float* input, float* output, int inc, int inh, int inw, int outh, int outw, int k_h,
+                      int k_w, int s_h, int s_w, int pad_h0, int pad_w0, int pad_h1, int pad_w1, int is_caffe)
+{
+    int in_hw = inw * inh;
+    int out_hw = outh * outw;
+
+    if (pad_w1 > 0)
+    {
+        outw--;
+    }
+    if (pad_h1 > 0)
+    {
+        outh--;
+    }
+    int block_w = outw >> 2;
+    int remain_w = inw - outw * 2;
+
+    const __m128 scalar_025 = _mm_set1_ps(0.25);
+    const __m128 scalar_05 = _mm_set1_ps(0.5);
+
+    for (int c = 0; c < inc; c++)
+    {
+        const float* line0 = input + c * in_hw;
+        const float* line1 = line0 + inw;
+        float* out_ptr = output + c * out_hw;
+
+        for (int i = 0; i < outh; i++)
+        {
+            for (int j = 0; j < block_w; j++)
+            {
+                __m128 p00 = _mm_loadu_ps(line0);
+                __m128 p01 = _mm_loadu_ps(line0 + 4);
+                __m128 p10 = _mm_loadu_ps(line1);
+                __m128 p11 = _mm_loadu_ps(line1 + 4);
+
+                __m128 r00 = _mm_shuffle_ps(p00, p01, _MM_SHUFFLE(2, 0, 2, 0));
+                __m128 r01 = _mm_shuffle_ps(p00, p01, _MM_SHUFFLE(3, 1, 3, 1));
+                __m128 r10 = _mm_shuffle_ps(p10, p11, _MM_SHUFFLE(2, 0, 2, 0));
+                __m128 r11 = _mm_shuffle_ps(p10, p11, _MM_SHUFFLE(3, 1, 3, 1));
+
+                __m128 sum0 = _mm_add_ps(r00, r01);
+                __m128 sum1 = _mm_add_ps(r10, r11);
+                __m128 sum = _mm_add_ps(sum0, sum1);
+
+                _mm_storeu_ps(out_ptr, _mm_mul_ps(sum, scalar_025));
+                line0 += 8;
+                line1 += 8;
+                out_ptr += 4;
+            }
+
+            for (int j = block_w * 4; j < outw; j++)
+            {
+                *out_ptr = (line0[0] + line0[1] + line1[0] + line1[1]) * 0.25f;
+
+                out_ptr++;
+                line0 += 2;
+                line1 += 2;
+            }
+
+            if (pad_w1 > 0)
+            {
+                *out_ptr = (line0[0] + line1[0]) * 0.5;
+                out_ptr++;
+            }
+            line0 += remain_w + inw;
+            line1 += remain_w + inw;
+        }
+
+        if (pad_h1 > 0)
+        {
+            for (int j = 0; j < block_w; j++)
+            {
+                __m128 p00 = _mm_loadu_ps(line0);
+                __m128 p01 = _mm_loadu_ps(line0 + 4);
+
+                __m128 r00 = _mm_shuffle_ps(p00, p01, _MM_SHUFFLE(2, 0, 2, 0));
+                __m128 r01 = _mm_shuffle_ps(p00, p01, _MM_SHUFFLE(3, 1, 3, 1));
+
+                __m128 sum = _mm_add_ps(r00, r01);
+                _mm_storeu_ps(out_ptr, _mm_mul_ps(sum, scalar_05));
+
+                line0 += 8;
+                out_ptr += 4;
+            }
+            for (int j = block_w * 4; j < outw; j++)
+            {
+                *out_ptr = (line0[0] + line0[1]) * 0.5;
+                out_ptr++;
+                line0 += 2;
+            }
+            if (pad_w1 > 0)
+            {
+                *out_ptr = line0[0];
+                out_ptr++;
+            }
+        }
+    }
+}
+
+static void max_2x2s2(const float* input, float* output, int inc, int inh, int inw, int outh, int outw, int k_h,
+                      int k_w, int s_h, int s_w, int pad_h0, int pad_w0, int pad_h1, int pad_w1, int is_caffe)
+{
+    int in_hw = inw * inh;
+    int out_hw = outh * outw;
+
+    if (pad_w1 > 0)
+    {
+        outw--;
+    }
+    if (pad_h1 > 0)
+    {
+        outh--;
+    }
+    int block_w = outw >> 2;
+    int remain_w = inw - outw * 2;
+
+    for (int c = 0; c < inc; c++)
+    {
+        const float* line0 = input + c * in_hw;
+        const float* line1 = line0 + inw;
+        float* out_ptr = output + c * out_hw;
+
+        for (int i = 0; i < outh; i++)
+        {
+            for (int j = 0; j < block_w; j++)
+            {
+                __m128 p00 = _mm_loadu_ps(line0);
+                __m128 p01 = _mm_loadu_ps(line0 + 4);
+                __m128 p10 = _mm_loadu_ps(line1);
+                __m128 p11 = _mm_loadu_ps(line1 + 4);
+
+                __m128 r00 = _mm_shuffle_ps(p00, p01, _MM_SHUFFLE(2, 0, 2, 0));
+                __m128 r01 = _mm_shuffle_ps(p00, p01, _MM_SHUFFLE(3, 1, 3, 1));
+                __m128 r10 = _mm_shuffle_ps(p10, p11, _MM_SHUFFLE(2, 0, 2, 0));
+                __m128 r11 = _mm_shuffle_ps(p10, p11, _MM_SHUFFLE(3, 1, 3, 1));
+
+                __m128 max0 = _mm_max_ps(r00, r01);
+                __m128 max1 = _mm_max_ps(r10, r11);
+                __m128 _max = _mm_max_ps(max0, max1);
+
+                _mm_storeu_ps(out_ptr, _max);
+                line0 += 8;
+                line1 += 8;
+                out_ptr += 4;
+            }
+
+            for (int j = block_w * 4; j < outw; j++)
+            {
+                float l0max = max(line0[0], line0[1]);
+                float l1max = max(line1[0], line1[1]);
+                *out_ptr = max(l0max, l1max);
+
+                out_ptr++;
+                line0 += 2;
+                line1 += 2;
+            }
+
+            if (pad_w1 > 0)
+            {
+                *out_ptr = max(line0[0], line1[0]);
+                out_ptr++;
+            }
+            line0 += remain_w + inw;
+            line1 += remain_w + inw;
+        }
+
+        if (pad_h1 > 0)
+        {
+            for (int j = 0; j < block_w; j++)
+            {
+                __m128 p00 = _mm_loadu_ps(line0);
+                __m128 p01 = _mm_loadu_ps(line0 + 4);
+
+                __m128 r00 = _mm_shuffle_ps(p00, p01, _MM_SHUFFLE(2, 0, 2, 0));
+                __m128 r01 = _mm_shuffle_ps(p00, p01, _MM_SHUFFLE(3, 1, 3, 1));
+
+                __m128 _max = _mm_max_ps(r00, r01);
+                _mm_storeu_ps(out_ptr, _max);
+
+                line0 += 8;
+                out_ptr += 4;
+            }
+            for (int j = block_w * 4; j < outw; j++)
+            {
+                *out_ptr = max(line0[0], line0[1]);
+                out_ptr++;
+                line0 += 2;
+            }
+            if (pad_w1 > 0)
+            {
+                *out_ptr = line0[0];
+                out_ptr++;
+            }
+        }
+    }
+}
+
+static void avg_3x3s2(const float* input, float* output, int inc, int inh, int inw, int outh, int outw, int k_h,
+                      int k_w, int s_h, int s_w, int pad_h0, int pad_w0, int pad_h1, int pad_w1, int is_caffe)
+{
+    int in_hw = inw * inh;
+    int out_hw = outh * outw;
+
+    if (pad_w1 > 0)
+    {
+        outw--;
+    }
+    if (pad_h1 > 0)
+    {
+        outh--;
+    }
+    int block_w = outw >> 2;
+    int remain_w = inw - outw * 2;
+    __m128 scalar_011 = _mm_set1_ps(0.11111111f);
+    __m128 scalar_016 = _mm_set1_ps(0.16666667f);
+    __m128 scalar_033 = _mm_set1_ps(0.3333333f);
+
+    for (int c = 0; c < inc; c++)
+    {
+        const float* line0 = input + c * in_hw;
+        const float* line1 = line0 + inw;
+        const float* line2 = line1 + inw;
+        float* out_ptr = output + c * out_hw;
+        for (int i = 0; i < outh; i++)
+        {
+            for (int j = 0; j < block_w; j++)
+            {
+                /*
+                p00     = [1,2,3,4,5,6,7,8]
+                p00.val[0]=[1,3,5,7]
+
+                max0    = [2,4,6,8]
+                p00_new = [9,10,11,12,13,14,15,16]
+                p01     = [3,5,7,9]
+                max0=max(max0,p01)=[3,5,7,9]
+                */
+
+                __m128 p00 = _mm_loadu_ps(line0);
+                __m128 p01 = _mm_loadu_ps(line0 + 1);
+                __m128 p02 = _mm_loadu_ps(line0 + 2);
+
+                __m128 p04 = _mm_loadu_ps(line0 + 4);
+                __m128 p05 = _mm_loadu_ps(line0 + 5);
+                __m128 p06 = _mm_loadu_ps(line0 + 6);
+
+                __m128 sum002 = _mm_add_ps(p00, p01);
+                sum002 = _mm_add_ps(sum002, p02);
+                __m128 sum046 = _mm_add_ps(p04, p05);
+                sum046 = _mm_add_ps(sum046, p06);
+
+                __m128 sum0 = _mm_shuffle_ps(sum002, sum046, _MM_SHUFFLE(2, 0, 2, 0));
+
+                __m128 p10 = _mm_loadu_ps(line1);
+                __m128 p11 = _mm_loadu_ps(line1 + 1);
+                __m128 p12 = _mm_loadu_ps(line1 + 2);
+
+                __m128 p14 = _mm_loadu_ps(line1 + 4);
+                __m128 p15 = _mm_loadu_ps(line1 + 5);
+                __m128 p16 = _mm_loadu_ps(line1 + 6);
+
+                __m128 sum102 = _mm_add_ps(p10, p11);
+                sum102 = _mm_add_ps(sum102, p12);
+                __m128 sum146 = _mm_add_ps(p14, p15);
+                sum146 = _mm_add_ps(sum146, p16);
+
+                __m128 sum1 = _mm_shuffle_ps(sum102, sum146, _MM_SHUFFLE(2, 0, 2, 0));
+
+                __m128 p20 = _mm_loadu_ps(line2);
+                __m128 p21 = _mm_loadu_ps(line2 + 1);
+                __m128 p22 = _mm_loadu_ps(line2 + 2);
+
+                __m128 p24 = _mm_loadu_ps(line2 + 4);
+                __m128 p25 = _mm_loadu_ps(line2 + 5);
+                __m128 p26 = _mm_loadu_ps(line2 + 6);
+
+                __m128 sum202 = _mm_add_ps(p20, p21);
+                sum202 = _mm_add_ps(sum202, p22);
+                __m128 sum246 = _mm_max_ps(p24, p25);
+                sum246 = _mm_add_ps(sum246, p26);
+
+                __m128 sum2 = _mm_shuffle_ps(sum202, sum246, _MM_SHUFFLE(2, 0, 2, 0));
+
+                __m128 avg = _mm_mul_ps(_mm_add_ps(_mm_add_ps(sum0, sum1), sum2), scalar_011);
+                _mm_storeu_ps(out_ptr, avg);
+
+                line0 += 8;
+                line1 += 8;
+                line2 += 8;
+                out_ptr += 4;
+            }
+            for (int j = block_w * 4; j < outw; j++)
+            {
+                float sum =
+                    line0[0] + line0[1] + line0[2] + line1[0] + line1[1] + line1[2] + line2[0] + line2[1] + line2[2];
+                *out_ptr = sum * 0.11111111f;
+
+                out_ptr++;
+                line0 += 2;
+                line1 += 2;
+                line2 += 2;
+            }
+            if (pad_w1 == 1)
+            {
+                *out_ptr = (line0[0] + line0[1] + line1[0] + line1[1] + line2[0] + line2[1]) * 0.16666667f;
+                out_ptr++;
+            }
+            line0 += remain_w + inw;
+            line1 += remain_w + inw;
+            line2 += remain_w + inw;
+        }
+        if (pad_h1 == 1)
+        {
+            for (int j = 0; j < block_w; j++)
+            {
+                __m128 p00 = _mm_loadu_ps(line0);
+                __m128 p01 = _mm_loadu_ps(line0 + 1);
+                __m128 p02 = _mm_loadu_ps(line0 + 2);
+
+                __m128 p04 = _mm_loadu_ps(line0 + 4);
+                __m128 p05 = _mm_loadu_ps(line0 + 5);
+                __m128 p06 = _mm_loadu_ps(line0 + 6);
+
+                __m128 sum002 = _mm_add_ps(p00, p01);
+                sum002 = _mm_add_ps(sum002, p02);
+                __m128 sum046 = _mm_add_ps(p04, p05);
+                sum046 = _mm_add_ps(sum046, p06);
+
+                __m128 sum0 = _mm_shuffle_ps(sum002, sum046, _MM_SHUFFLE(2, 0, 2, 0));
+
+                __m128 p10 = _mm_loadu_ps(line1);
+                __m128 p11 = _mm_loadu_ps(line1 + 1);
+                __m128 p12 = _mm_loadu_ps(line1 + 2);
+
+                __m128 p14 = _mm_loadu_ps(line1 + 4);
+                __m128 p15 = _mm_loadu_ps(line1 + 5);
+                __m128 p16 = _mm_loadu_ps(line1 + 6);
+
+                __m128 sum102 = _mm_add_ps(p10, p11);
+                sum102 = _mm_add_ps(sum102, p12);
+                __m128 sum146 = _mm_add_ps(p14, p15);
+                sum146 = _mm_add_ps(sum146, p16);
+
+                __m128 sum1 = _mm_shuffle_ps(sum102, sum146, _MM_SHUFFLE(2, 0, 2, 0));
+
+                _mm_storeu_ps(out_ptr, _mm_mul_ps(_mm_add_ps(sum0, sum1), scalar_016));
+
+                line0 += 8;
+                line1 += 8;
+                out_ptr += 4;
+            }
+            for (int j = block_w * 4; j < outw; j++)
+            {
+                *out_ptr = (line0[0] + line0[1] + line0[2] + line1[0] + line1[1] + line1[2]) * 0.16666667f;
+                out_ptr++;
+                line0 += 2;
+                line1 += 2;
+            }
+            if (pad_w1 == 1)
+            {
+                *out_ptr = (line0[0] + line0[1] + line1[0] + line1[1]) * 0.25f;
+                out_ptr++;
+            }
+            else if (pad_w1 == 2)
+            {
+                *out_ptr = (line0[0] + line1[0]) * 0.5f;
+                out_ptr++;
+            }
+        }
+        else if (pad_h1 == 2)
+        {
+            for (int j = 0; j < block_w; j++)
+            {
+                __m128 p00 = _mm_loadu_ps(line0);
+                __m128 p01 = _mm_loadu_ps(line0 + 1);
+                __m128 p02 = _mm_loadu_ps(line0 + 2);
+
+                __m128 p04 = _mm_loadu_ps(line0 + 4);
+                __m128 p05 = _mm_loadu_ps(line0 + 5);
+                __m128 p06 = _mm_loadu_ps(line0 + 6);
+
+                __m128 sum002 = _mm_add_ps(p00, p01);
+                sum002 = _mm_add_ps(sum002, p02);
+                __m128 sum046 = _mm_add_ps(p04, p05);
+                sum046 = _mm_add_ps(sum046, p06);
+
+                __m128 sum0 = _mm_shuffle_ps(sum002, sum046, _MM_SHUFFLE(2, 0, 2, 0));
+
+                _mm_storeu_ps(out_ptr, _mm_mul_ps(sum0, scalar_033));
+
+                line0 += 8;
+                out_ptr += 4;
+            }
+            for (int j = block_w * 4; j < outw; j++)
+            {
+                *out_ptr = (line0[0] + line0[1] + line0[2]) * 0.3333333f;
+                out_ptr++;
+                line0 += 2;
+            }
+            if (pad_w1 == 1)
+            {
+                *out_ptr = (line0[0] + line0[1]) * 0.5f;
+                out_ptr++;
+            }
+            else if (pad_w1 == 2)
+            {
+                *out_ptr = line0[0];
+                out_ptr++;
+            }
+        }
+    }
+}
+
+static void avg_3x3s2_p1(const float* input, float* output, int inc, int inh, int inw, int outh, int outw, int k_h,
+                         int k_w, int s_h, int s_w, int pad_h0, int pad_w0, int pad_h1, int pad_w1, int is_caffe)
+{
+    int in_hw = inw * inh;
+    int out_hw = outh * outw;
+
+    if (is_caffe == 1 || inw % 2 == 1)
+        outw--;
+    if (is_caffe == 1 || inh % 2 == 1)
+        outh--;
+    int block_w = (outw - 1) >> 2;
+    int remain_w = inw - outw * 2 + 1;
+
+    __m128 scalar_011 = _mm_set1_ps(0.11111111f);
+    __m128 scalar_016 = _mm_set1_ps(0.16666667f);
+    __m128 scalar_033 = _mm_set1_ps(0.3333333f);
+
+    for (int c = 0; c < inc; c++)
+    {
+        const float* line1 = input + c * in_hw;
+        const float* line2 = line1 + inw;
+        float* out_ptr = output + c * out_hw;
+
+        // h begin ---------------------------------------
+        if (is_caffe == 0)
+            *out_ptr = (line1[0] + line1[1] + line2[0] + line2[1]) * 0.25f;
+        else
+            *out_ptr = (line1[0] + line1[1] + line2[0] + line2[1]) * 0.11111111f;
+        out_ptr++;
+        line1 += 1;
+        line2 += 1;
+        for (int j = 0; j < block_w; j++)
+        {
+            __m128 p00 = _mm_loadu_ps(line1);
+            __m128 p01 = _mm_loadu_ps(line1 + 1);
+            __m128 p02 = _mm_loadu_ps(line1 + 2);
+
+            __m128 p04 = _mm_loadu_ps(line1 + 4);
+            __m128 p05 = _mm_loadu_ps(line1 + 5);
+            __m128 p06 = _mm_loadu_ps(line1 + 6);
+
+            __m128 sum002 = _mm_add_ps(p00, p01);
+            sum002 = _mm_add_ps(sum002, p02);
+            __m128 sum046 = _mm_add_ps(p04, p05);
+            sum046 = _mm_add_ps(sum046, p06);
+
+            __m128 sum0 = _mm_shuffle_ps(sum002, sum046, _MM_SHUFFLE(2, 0, 2, 0));
+
+            __m128 p10 = _mm_loadu_ps(line2);
+            __m128 p11 = _mm_loadu_ps(line2 + 1);
+            __m128 p12 = _mm_loadu_ps(line2 + 2);
+
+            __m128 p14 = _mm_loadu_ps(line2 + 4);
+            __m128 p15 = _mm_loadu_ps(line2 + 5);
+            __m128 p16 = _mm_loadu_ps(line2 + 6);
+
+            __m128 sum102 = _mm_add_ps(p10, p11);
+            sum102 = _mm_add_ps(sum102, p12);
+            __m128 sum146 = _mm_add_ps(p14, p15);
+            sum146 = _mm_add_ps(sum146, p16);
+
+            __m128 sum1 = _mm_shuffle_ps(sum102, sum146, _MM_SHUFFLE(2, 0, 2, 0));
+            if (is_caffe == 0)
+                sum1 = _mm_mul_ps(_mm_add_ps(sum1, sum0), scalar_016);
+            else
+                sum1 = _mm_mul_ps(_mm_add_ps(sum1, sum0), scalar_011);
+            _mm_storeu_ps(out_ptr, sum1);
+
+            line1 += 8;
+            line2 += 8;
+            out_ptr += 4;
+        }
+        for (int j = block_w * 4 + 1; j < outw; j++)
+        {
+            if (is_caffe == 0)
+                *out_ptr = (line1[0] + line1[1] + line1[2] + line2[0] + line2[1] + line2[2]) * 0.16666667f;
+            else
+                *out_ptr = (line1[0] + line1[1] + line1[2] + line2[0] + line2[1] + line2[2]) * 0.11111111f;
+            out_ptr++;
+            line1 += 2;
+            line2 += 2;
+        }
+        if (inw % 2 == 1)
+        {
+            if (is_caffe == 0)
+                *out_ptr = (line1[0] + line1[1] + line2[0] + line2[1]) * 0.25f;
+            else
+                *out_ptr = (line1[0] + line1[1] + line2[0] + line2[1]) * 0.11111111f;
+            out_ptr++;
+        }
+        else if (inw % 2 == 0 && is_caffe == 1)
+        {
+            *out_ptr = (line1[0] + line2[0]) * 0.16666667f;
+            out_ptr++;
+        }
+        line1 += remain_w;
+        line2 += remain_w;
+
+        // h center ---------------------------------------
+        const float* line0 = line1;
+        line1 = line2;
+        line2 = line1 + inw;
+        for (int i = 1; i < outh; i++)
+        {
+            // left
+            if (is_caffe == 0)
+                *out_ptr = (line0[0] + line0[1] + line1[0] + line1[1] + line2[0] + line2[1]) * 0.16666667f;
+            else
+                *out_ptr = (line0[0] + line0[1] + line1[0] + line1[1] + line2[0] + line2[1]) * 0.11111111f;
+            out_ptr++;
+            line0 += 1;
+            line1 += 1;
+            line2 += 1;
+            // mid
+            for (int j = 0; j < block_w; j++)
+            {
+                __m128 p00 = _mm_loadu_ps(line0);
+                __m128 p01 = _mm_loadu_ps(line0 + 1);
+                __m128 p02 = _mm_loadu_ps(line0 + 2);
+
+                __m128 p04 = _mm_loadu_ps(line0 + 4);
+                __m128 p05 = _mm_loadu_ps(line0 + 5);
+                __m128 p06 = _mm_loadu_ps(line0 + 6);
+
+                __m128 sum002 = _mm_add_ps(p00, p01);
+                sum002 = _mm_add_ps(sum002, p02);
+                __m128 sum046 = _mm_add_ps(p04, p05);
+                sum046 = _mm_add_ps(sum046, p06);
+
+                __m128 sum0 = _mm_shuffle_ps(sum002, sum046, _MM_SHUFFLE(2, 0, 2, 0));
+
+                __m128 p10 = _mm_loadu_ps(line1);
+                __m128 p11 = _mm_loadu_ps(line1 + 1);
+                __m128 p12 = _mm_loadu_ps(line1 + 2);
+
+                __m128 p14 = _mm_loadu_ps(line1 + 4);
+                __m128 p15 = _mm_loadu_ps(line1 + 5);
+                __m128 p16 = _mm_loadu_ps(line1 + 6);
+
+                __m128 sum102 = _mm_add_ps(p10, p11);
+                sum102 = _mm_add_ps(sum102, p12);
+                __m128 sum146 = _mm_add_ps(p14, p15);
+                sum146 = _mm_add_ps(sum146, p16);
+
+                __m128 sum1 = _mm_shuffle_ps(sum102, sum146, _MM_SHUFFLE(2, 0, 2, 0));
+
+                __m128 p20 = _mm_loadu_ps(line2);
+                __m128 p21 = _mm_loadu_ps(line2 + 1);
+                __m128 p22 = _mm_loadu_ps(line2 + 2);
+
+                __m128 p24 = _mm_loadu_ps(line2 + 4);
+                __m128 p25 = _mm_loadu_ps(line2 + 5);
+                __m128 p26 = _mm_loadu_ps(line2 + 6);
+
+                __m128 sum202 = _mm_add_ps(p20, p21);
+                sum202 = _mm_add_ps(sum202, p22);
+                __m128 sum246 = _mm_max_ps(p24, p25);
+                sum246 = _mm_add_ps(sum246, p26);
+
+                __m128 sum2 = _mm_shuffle_ps(sum202, sum246, _MM_SHUFFLE(2, 0, 2, 0));
+
+                __m128 avg = _mm_mul_ps(_mm_add_ps(_mm_add_ps(sum0, sum1), sum2), scalar_011);
+                _mm_storeu_ps(out_ptr, avg);
+
+                line0 += 8;
+                line1 += 8;
+                line2 += 8;
+                out_ptr += 4;
+            }
+            for (int j = block_w * 4 + 1; j < outw; j++)
+            {
+                *out_ptr =
+                    (line0[0] + line0[1] + line0[2] + line1[0] + line1[1] + line1[2] + line2[0] + line2[1] + line2[2]) *
+                    0.11111111f;
+                out_ptr++;
+                line0 += 2;
+                line1 += 2;
+                line2 += 2;
+            }
+            // end
+            if (inw % 2 == 1)
+            {
+                if (is_caffe == 0)
+                    *out_ptr = (line0[0] + line0[1] + line1[0] + line1[1] + line2[0] + line2[1]) * 0.16666667f;
+                else
+                    *out_ptr = (line0[0] + line0[1] + line1[0] + line1[1] + line2[0] + line2[1]) * 0.11111111f;
+                out_ptr++;
+            }
+            else if (inw % 2 == 0 && is_caffe == 1)
+            {
+                *out_ptr = (line0[0] + line1[0] + line2[0]) * 0.16666667f;
+                out_ptr++;
+            }
+            line0 += remain_w + inw;
+            line1 += remain_w + inw;
+            line2 += remain_w + inw;
+        }
+        // h  end-------------------------------
+        if (inh % 2 == 1)
+        {
+            if (is_caffe == 0)
+                *out_ptr = (line0[0] + line0[1] + line1[0] + line1[1]) * 0.25f;
+            else
+                *out_ptr = (line0[0] + line0[1] + line1[0] + line1[1]) * 0.11111111f;
+            out_ptr++;
+            line0 += 1;
+            line1 += 1;
+
+            for (int j = 0; j < block_w; j++)
+            {
+                __m128 p00 = _mm_loadu_ps(line0);
+                __m128 p01 = _mm_loadu_ps(line0 + 1);
+                __m128 p02 = _mm_loadu_ps(line0 + 2);
+
+                __m128 p04 = _mm_loadu_ps(line0 + 4);
+                __m128 p05 = _mm_loadu_ps(line0 + 5);
+                __m128 p06 = _mm_loadu_ps(line0 + 6);
+
+                __m128 sum002 = _mm_add_ps(p00, p01);
+                sum002 = _mm_add_ps(sum002, p02);
+                __m128 sum046 = _mm_add_ps(p04, p05);
+                sum046 = _mm_add_ps(sum046, p06);
+
+                __m128 sum0 = _mm_shuffle_ps(sum002, sum046, _MM_SHUFFLE(2, 0, 2, 0));
+
+                __m128 p10 = _mm_loadu_ps(line1);
+                __m128 p11 = _mm_loadu_ps(line1 + 1);
+                __m128 p12 = _mm_loadu_ps(line1 + 2);
+
+                __m128 p14 = _mm_loadu_ps(line1 + 4);
+                __m128 p15 = _mm_loadu_ps(line1 + 5);
+                __m128 p16 = _mm_loadu_ps(line1 + 6);
+
+                __m128 sum102 = _mm_add_ps(p10, p11);
+                sum102 = _mm_add_ps(sum102, p12);
+                __m128 sum146 = _mm_add_ps(p14, p15);
+                sum146 = _mm_add_ps(sum146, p16);
+
+                __m128 sum1 = _mm_shuffle_ps(sum102, sum146, _MM_SHUFFLE(2, 0, 2, 0));
+                if (is_caffe == 0)
+                    sum1 = _mm_mul_ps(_mm_add_ps(sum1, sum0), scalar_016);
+                else
+                    sum1 = _mm_mul_ps(_mm_add_ps(sum1, sum0), scalar_011);
+                _mm_storeu_ps(out_ptr, sum1);
+
+                line0 += 8;
+                line1 += 8;
+                out_ptr += 4;
+            }
+            for (int j = block_w * 4 + 1; j < outw; j++)
+            {
+                if (is_caffe == 0)
+                    *out_ptr = (line0[0] + line0[1] + line0[2] + line1[0] + line1[1] + line1[2]) * 0.16666667f;
+                else
+                    *out_ptr = (line0[0] + line0[1] + line0[2] + line1[0] + line1[1] + line1[2]) * 0.11111111f;
+                out_ptr++;
+                line0 += 2;
+                line1 += 2;
+            }
+            if (inw % 2 == 1)
+            {
+                if (is_caffe == 0)
+                    *out_ptr = (line0[0] + line0[1] + line1[0] + line1[1]) * 0.25f;
+                else
+                    *out_ptr = (line0[0] + line0[1] + line1[0] + line1[1]) * 0.11111111f;
+                out_ptr++;
+            }
+            else if (inw % 2 == 0 && is_caffe == 1)
+            {
+                *out_ptr = (line0[0] + line1[0]) * 0.16666667f;
+                out_ptr++;
+            }
+        }
+        else if (inw % 2 == 0 && is_caffe == 1)
+        {
+            *out_ptr = (line0[0] + line0[1]) * 0.16666667f;
+            out_ptr++;
+            line0 += 1;
+
+            for (int j = 0; j < block_w; j++)
+            {
+                __m128 p00 = _mm_loadu_ps(line0);
+                __m128 p01 = _mm_loadu_ps(line0 + 1);
+                __m128 p02 = _mm_loadu_ps(line0 + 2);
+
+                __m128 p04 = _mm_loadu_ps(line0 + 4);
+                __m128 p05 = _mm_loadu_ps(line0 + 5);
+                __m128 p06 = _mm_loadu_ps(line0 + 6);
+
+                __m128 sum002 = _mm_add_ps(p00, p01);
+                sum002 = _mm_add_ps(sum002, p02);
+                __m128 sum046 = _mm_add_ps(p04, p05);
+                sum046 = _mm_add_ps(sum046, p06);
+
+                __m128 sum0 = _mm_shuffle_ps(sum002, sum046, _MM_SHUFFLE(2, 0, 2, 0));
+
+                _mm_storeu_ps(out_ptr, _mm_mul_ps(sum0, scalar_016));
+
+                line0 += 8;
+                out_ptr += 4;
+            }
+            for (int j = block_w * 4 + 1; j < outw; j++)
+            {
+                *out_ptr = (line0[0] + line0[1] + line0[2]) * 0.16666667f;
+                out_ptr++;
+                line0 += 2;
+            }
+            if (inw % 2 == 1)
+            {
+                *out_ptr = (line0[0] + line0[1]) * 0.16666667f;
+                out_ptr++;
+            }
+            else if (inw % 2 == 0)
+            {
+                *out_ptr = line0[0] * 0.25f;
+                out_ptr++;
+            }
+        }
+    }
+}
+
+static void avg_global(const float* input, float* output, int inc, int inh, int inw, int outh, int outw, int k_h,
+                       int k_w, int s_h, int s_w, int pad_h0, int pad_w0, int pad_h1, int pad_w1, int is_caffe)
+{
+    int in_hw = inw * inh;
+    int block = in_hw >> 3;
+    int tail = in_hw & ~7;
+
+    for (int c = 0; c < inc; c++)
+    {
+        const float* line0 = input + c * in_hw;
+        float* out_ptr = output + c;
+        float sum = 0.f;
+        for (int j = 0; j < block; j++)
+        {
+            __m128 p00 = _mm_loadu_ps(line0);
+            __m128 p01 = _mm_loadu_ps(line0 + 4);
+            p00 = _mm_add_ps(p00, p01);
+
+            sum += (p00[0] + p00[1] + p00[2] + p00[3]);
+            line0 += 8;
+        }
+        for (int j = tail; j < in_hw; j++)
+        {
+            sum += line0[0];
+            line0++;
+        }
+        *out_ptr = sum / in_hw;
+    }
+}
+static void max_global(const float* input, float* output, int inc, int inh, int inw, int outh, int outw, int k_h,
+                       int k_w, int s_h, int s_w, int pad_h0, int pad_w0, int pad_h1, int pad_w1, int is_caffe)
+{
+    int in_hw = inw * inh;
+    int block = in_hw >> 3;
+    int tail = in_hw & ~7;
+
+    for (int c = 0; c < inc; c++)
+    {
+        const float* line0 = input + c * in_hw;
+        float* out_ptr = output + c;
+        __m128 p00 = _mm_loadu_ps(line0);
+        __m128 res = p00;
+        for (int j = 0; j < block; j++)
+        {
+            __m128 p00 = _mm_loadu_ps(line0);
+            __m128 p01 = _mm_loadu_ps(line0 + 4);
+            __m128 max0 = _mm_max_ps(p00, p01);
+            res = _mm_max_ps(res, max0);
+            line0 += 8;
+        }
+        float max_ = max(max(res[0], res[1]), max(res[2], res[3]));
+        for (int j = tail; j < in_hw; j++)
+        {
+            max_ = max(max_, line0[0]);
+            line0++;
+        }
+        *out_ptr = max_;
+    }
+}
+
+int pooling_kernel_perf_prerun(struct ir_tensor* input, struct ir_tensor* out, struct pool_param* param)
+{
+    int pool_size = POOL_GENERIC;
+
+    /* global pooling */
+    if (param->global)
+    {
+        if (param->pool_method == POOL_AVG)
+            param->funct = ( pooling_kernel_t )avg_global;
+        else if (param->pool_method == POOL_MAX)
+            param->funct = ( pooling_kernel_t )max_global;
+
+        assert(param->funct != NULL);
+        return 0;
+    }
+
+    /* general pooling */
+    if (param->stride_h == 2 && param->stride_w == 2)
+    {
+        if (param->kernel_h == 2 && param->kernel_w == 2)
+            pool_size = POOL_K2S2;
+        else if (param->kernel_h == 3 && param->kernel_w == 3)
+            pool_size = POOL_K3S2;
+    }
+    else if (param->stride_h == 1 && param->stride_w == 1)
+    {
+        if (param->kernel_h == 3 && param->kernel_w == 3)
+            pool_size = POOL_K3S1;
+    }
+
+    /* general max pooling, k2s2, k2k2p1, k3s1p1, k3s2, k3s2p1 */
+    if (param->pool_method == POOL_MAX)
+    {
+        if ((param->pad_h0 == param->pad_w0) && (param->pad_h1 == param->pad_w1))
+        {
+            if (param->pad_h0 == 0)
+            {
+                if (pool_size == POOL_K2S2)
+                    param->funct = ( pooling_kernel_t )max_2x2s2;
+                else if (pool_size == POOL_K3S2)
+                    param->funct = ( pooling_kernel_t )max_3x3s2;
+            }
+            else if (param->pad_h0 == 1)
+            {
+                if (pool_size == POOL_K2S2)
+                    param->funct = ( pooling_kernel_t )max_2x2s2_p1;
+                else if (pool_size == POOL_K3S2)
+                    param->funct = ( pooling_kernel_t )max_3x3s2_p1;
+                else if (pool_size == POOL_K3S1)
+                    param->funct = ( pooling_kernel_t )max_3x3s1_p1;
+            }
+        }
+
+        if (param->funct != NULL)
+            return 0;
+        else
+        {
+            fprintf(stderr, "perf general max pooling func not be find\n");
+            return -1;
+        }
+    }
+
+    /* general avg pooling, k2s2, k2s2p1, k3s2, k3s2p1 */
+    if (param->pool_method == POOL_AVG)
+    {
+        if ((param->pad_h0 == param->pad_w0) && (param->pad_h1 == param->pad_w1))
+        {
+            if (param->pad_h0 == 0 && param->pad_h1 == 0)
+            {
+                if (pool_size == POOL_K2S2)
+                    param->funct = ( pooling_kernel_t )avg_2x2s2;
+                else if (pool_size == POOL_K3S2)
+                    param->funct = ( pooling_kernel_t )avg_3x3s2;
+            }
+            else if (param->pad_h0 == 1 && param->pad_h1 == 1)
+            {
+                if (pool_size == POOL_K2S2)
+                    param->funct = ( pooling_kernel_t )avg_2x2s2_p1;
+                else if (pool_size == POOL_K3S2)
+                    param->funct = ( pooling_kernel_t )avg_3x3s2_p1;
+            }
+        }
+
+        if (param->funct != NULL)
+            return 0;
+        else
+        {
+            fprintf(stderr, "perf general avg pooling func not be find\n");
+            return -1;
+        }
+    }
+
+    fprintf(stderr, "perf pooling func not be find\n");
+    return -1;
+}
+
+int pooling_kernel_perf_run(struct ir_tensor* input, struct ir_tensor* output, struct pool_param* param, int num_thread)
+{
+    // fprintf(stderr, "perf pooling_kernel_run\n");
+    int is_caffe = param->caffe_flavor;
+    pooling_kernel_t kernel = (pooling_kernel_t)(param->funct);
+
+    int batch = input->dims[0];
+    int c = input->dims[1];
+    int in_h = input->dims[2];
+    int in_w = input->dims[3];
+
+    int out_h = output->dims[2];
+    int out_w = output->dims[3];
+
+    int img_size = c * in_h * in_w;
+    int feature_size = c * out_h * out_w;
+
+    for (int n = 0; n < batch; n++)
+    {
+        void* input_frame = input->data + n * img_size * input->elem_size;
+        void* output_frame = output->data + n * feature_size * output->elem_size;
+
+#pragma omp parallel for num_threads(num_thread)
+        for (int ch = 0; ch < c; ch++)
+        {
+            void* cur_input = input_frame + ch * in_h * in_w * input->elem_size;
+            void* cur_output = output_frame + ch * out_h * out_w * output->elem_size;
+            kernel(cur_input, cur_output, 1, in_h, in_w, out_h, out_w, param->kernel_h, param->kernel_w,
+                   param->stride_h, param->stride_w, param->pad_h0, param->pad_w0, param->pad_h1, param->pad_w1,
+                   is_caffe);
+        }
+    }
+
+    return 0;
+}


### PR DESCRIPTION
测试模型：

class TestPoolPadding(torch.nn.Module):
    def __init__(self):
        super(TestPoolPadding, self).__init__()
        self.max3x3s2p1 = torch.nn.MaxPool2d(kernel_size=3, stride=2, padding=1)
        self.max3x3s1p1 = torch.nn.MaxPool2d(kernel_size=3, stride=1, padding=1)
    def forward(self, x):
        x1 = self.max3x3s1p1(x)
        x2 = self.max3x3s2p1(x)
        return x1, x2

class TestPool(torch.nn.Module):
    def __init__(self):
        super(TestPool, self).__init__()
        self.avgpool_2x2s2 = torch.nn.AvgPool2d(kernel_size=2, stride=2)
        self.avgpool_3x3s2 = torch.nn.AvgPool2d(kernel_size=3, stride=2)
        self.maxpool_2x2s2 = torch.nn.MaxPool2d(kernel_size=2, stride=2)
        self.maxpool_3x3s1 = torch.nn.MaxPool2d(kernel_size=3, stride=1)
        self.maxpool_3x3s2 = torch.nn.MaxPool2d(kernel_size=3, stride=2)


    def forward(self, x):
        x1 = self.avgpool_2x2s2(x)
        x2 = self.avgpool_3x3s2(x)

        x3 = self.maxpool_2x2s2(x)
        x4 = self.maxpool_3x3s1(x)
        x5 = self.maxpool_3x3s2(x)
        return x1, x2, x3, x4, x5

class GlobalPooing(torch.nn.Module):
    def __init__(self):
        super(GlobalPooing,self).__init__()
        self.global_avg = torch.nn.AdaptiveAvgPool2d(output_size=(1, 1))
        self.global_max = torch.nn.AdaptiveMaxPool2d(output_size=(1, 1))
    def forward(self, x):
        x1 = self.global_avg(x)
        x2 = self.global_max(x)
        return x1, x2

已经测试过输出是一致的。  各个算子的速度普遍快了2倍以上