### PR TITLE
build support for Harmony os tengine lite

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -99,6 +99,11 @@ endif()
 add_definitions(-fPIC)
 add_definitions(-O3)
 
+# OHOS 3.0.0.80 patch for ASM language
+if (OHOS AND NOT DEFINED CMAKE_ASM_COMPILER_TARGET)
+    set(CMAKE_ASM_COMPILER_TARGET ${OHOS_LLVM})
+endif()
+
 if (${TENGINE_TARGET_PROCESSOR} MATCHES "ARM")
     if (TENGINE_TARGET_PROCESSOR_32Bit AND NOT ANDROID)
         add_definitions(-march=armv7-a)

--- a/doc/compile.md
+++ b/doc/compile.md
@@ -194,9 +194,10 @@ cmake -G Ninja ^
     -DCMAKE_TOOLCHAIN_FILE=%TOOLCHAIN% ^
     -DOHOS_ARCH="arm64-v8a" ^
     -DCMAKE_BUILD_TYPE=Release ^
+    -DCMAKE_BUILD_WITH_INSTALL_RPATH=ON ^
     ../..
 
-#ninja
+::ninja
 cmake --build .
 
 cd ..

--- a/doc/compile.md
+++ b/doc/compile.md
@@ -147,6 +147,61 @@ make install
 
 请参考 [Tengine Lite Vulkan GPU 使用说明](gpu_vulkan_user_manual.md)。
 
-## 5. 总结
+## 5. 交叉编译 Arm64 OHOS（鸿蒙系统） 版本
+
+### 5.1 安装 DevEco Studio 和 OHOS NDK
+
+下载安装 DevEco Studio，[传送门](https://developer.harmonyos.com/cn/develop/deveco-studio#download)。若没有华为开发者账号，需到[HarmonysOS应用开发门户](https://developer.harmonyos.com/cn/home)注册。
+
+打开 DevEco Studio，Configure（或File）-> Settings -> Appearance & Behavior -> System Settings -> HarmonyOS SDK，勾选并下载 Native，完成 OHOS NDK 下载。
+
+### 5.2 准备 OHOS NDK cmake toolchain 文件
+
+ohos.toolchain.cmake 这个文件可以从 $OHOS_NDK/build/cmake 找到，例如 E:\soft\Huawei\sdk\native\3.0.0.80\build\cmake\ohos.toolchain.cmake
+
+(可选) 删除debug编译参数，缩小二进制体积，方法和 android ndk相同 [android-ndk issue](https://github.com/android-ndk/ndk/issues/243)
+
+```
+# 用编辑器打开 $ANDROID_NDK/build/cmake/android.toolchain.cmake
+# 删除 "-g" 这行
+list(APPEND ANDROID_COMPILER_FLAGS
+  -g
+  -DANDROID
+```
+
+### 5.3 下载 Tengine Lite 源码
+
+```bash
+git clone -b tengine-lite https://github.com/OAID/Tengine.git Tengine-Lite
+```
+
+### 5.4 编译 Tengine Lite
+
+Arm64 OHOS 编译脚本如下（Windows）
+
+`build/ohos-arm64-v8a.bat`:
+```bash
+@echo off
+
+set OHOS_NDK=E:/soft/Huawei/sdk/native/3.0.0.80
+set TOOLCHAIN=%OHOS_NDK%/build/cmake/ohos.toolchain.cmake
+
+set BUILD_DIR=ohos-arm64-v8a
+if not exist %BUILD_DIR% md %BUILD_DIR%
+cd %BUILD_DIR%
+
+cmake -G Ninja ^
+    -DCMAKE_TOOLCHAIN_FILE=%TOOLCHAIN% ^
+    -DOHOS_ARCH="arm64-v8a" ^
+    -DCMAKE_BUILD_TYPE=Release ^
+    ../..
+
+#ninja
+cmake --build .
+
+cd ..
+```
+
+## 6. 总结
 
 本文档只是简单指导如何编译对应的 Tengine Lite 版本，有需要可以参考 ` Tengine-Lite/build.sh` 文件。

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -165,6 +165,8 @@ target_include_directories(${CMAKE_PROJECT_NAME} PRIVATE ${TENGINE_PRIVATE_INC_D
 
 if (ANDROID)
     target_link_libraries(${CMAKE_PROJECT_NAME} android ${TENGINE_LINKING_LIBS})
+elseif(OHOS)
+    target_link_libraries(${CMAKE_PROJECT_NAME} ${TENGINE_LINKING_LIBS})
 else()
     target_link_libraries(${CMAKE_PROJECT_NAME} pthread dl m ${TENGINE_LINKING_LIBS})
 endif()

--- a/src/lib/cpu.c
+++ b/src/lib/cpu.c
@@ -215,7 +215,7 @@ static int set_sched_affinity(size_t thread_affinity_mask)
 #define CPU_ZERO(cpusetp) memset((cpusetp), 0, sizeof(cpu_set_t))
 
     // set affinity for thread
-#ifdef __GLIBC__
+#if defined(__GLIBC__) || defined(__OHOS__)
     pid_t pid = syscall(SYS_gettid);
 #else
 #ifdef PI3


### PR DESCRIPTION
基于OHOS NDK 3.0.0.80 编译出了 libtengine-lite.so

![image](https://user-images.githubusercontent.com/3831847/97667200-4f345100-1aba-11eb-93cb-a91a222ee965.png)

感谢 https://github.com/OAID/Tengine/issues/452
