### PR TITLE
add timvx x86 simulator to codecov and ci

### DIFF
--- a/.github/workflows/test-coverage.yml
+++ b/.github/workflows/test-coverage.yml
@@ -54,6 +54,15 @@ jobs:
       run: sudo apt-get install libopencv-dev
     - name: lcov
       run: sudo apt-get install lcov
+    - name: tim-vx
+      run: |
+        git clone https://github.com/VeriSilicon/TIM-VX.git
+        mkdir -p ./3rdparty/tim-vx/lib/x86_64
+        mkdir -p ./3rdparty/tim-vx/include
+        cp -rf ./TIM-VX/include/*    ./3rdparty/tim-vx/include/
+        cp -rf ./TIM-VX/src    ./src/dev/tim-vx/
+        cp -rf ./TIM-VX/prebuilt-sdk/x86_64_linux/include/*    ./3rdparty/tim-vx/include/
+        cp -rf ./TIM-VX/prebuilt-sdk/x86_64_linux/lib/*    ./3rdparty/tim-vx/lib/x86_64/      
     - name: configure
       run: mkdir build && cd build && cmake -DCMAKE_BUILD_TYPE=debug -DTENGINE_ENABLE_TIM_VX=ON -DTENGINE_ENABLE_TIM_VX_INTEGRATION=ON -DTENGINE_COVERAGE=ON ..
     - name: build

--- a/.github/workflows/test-coverage.yml
+++ b/.github/workflows/test-coverage.yml
@@ -76,6 +76,7 @@ jobs:
     - name: test-timvx-simulator
       run: |
         cd build
+        export LD_LIBRARY_PATH=../3rdparty/tim-vx/lib/x86_64/
         ./examples/tm_classification_timvx -m ./tengine_test_data/mobilenet_uint8.tmfile -i ./images/cat.jpg -g 224,224, -s 0.017,0.017,0.017
         ./examples/tm_classification_timvx -m ./tengine_test_data/squeezenet_uint8.tmfile -i ./images/cat.jpg -g 227,227, -s 0.017,0.017,0.017
     - name: lcov-collect

--- a/.github/workflows/test-coverage.yml
+++ b/.github/workflows/test-coverage.yml
@@ -43,7 +43,7 @@ jobs:
         token: ${{ secrets.CODECOV_TOKEN }}
         file: build/lcov.info
 
-jobs:
+
   linux-gcc-x86-timvx-simulator:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/test-coverage.yml
+++ b/.github/workflows/test-coverage.yml
@@ -12,7 +12,7 @@ jobs:
     - name: protobuf
       run: sudo apt-get install libopencv-dev
     - name: lcov
-      run: sudo apt-get install lcov      
+      run: sudo apt-get install lcov
     - name: configure
       run: mkdir build && cd build && cmake -DCMAKE_BUILD_TYPE=debug -DTENGINE_BUILD_TESTS=ON -DTENGINE_COVERAGE=ON ..
     - name: build
@@ -27,7 +27,7 @@ jobs:
         mv x86_data data
         wget http://139.180.196.82/lite/images.zip
         unzip images.zip
-    - name: test
+    - name: test-cpu
       run: |
         cd build
         ../tests/test.sh
@@ -37,6 +37,47 @@ jobs:
         lcov -d ./src -c -o lcov.info
         lcov -r lcov.info '/usr/*' -o lcov.info
         lcov --list lcov.info
+    - name: codecov
+      uses: codecov/codecov-action@v1.0.11
+      with:
+        token: ${{ secrets.CODECOV_TOKEN }}
+        file: build/lcov.info
+
+jobs:
+  linux-gcc-x86-timvx-simulator:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v1
+    - name: update
+      run: sudo apt-get update
+    - name: protobuf
+      run: sudo apt-get install libopencv-dev
+    - name: lcov
+      run: sudo apt-get install lcov
+    - name: configure
+      run: mkdir build && cd build && cmake -DCMAKE_BUILD_TYPE=debug -DTENGINE_ENABLE_TIM_VX=ON -DTENGINE_ENABLE_TIM_VX_INTEGRATION=ON -DTENGINE_COVERAGE=ON ..
+    - name: build
+      run: cmake --build build -j 2
+    - name: models
+      run: |
+        cd build
+        wget http://139.180.196.82/lite/images.zip
+        unzip images.zip
+        git clone https://github.com/BUG1989/tengine_test_data.git
+    - name: test-timvx-simulator
+      run: |
+        cd build
+        ./examples/tm_classification_timvx -m ./tengine_test_data/mobilenet_uint8.tmfile -i ./images/cat.jpg -g 224,224, -s 0.017,0.017,0.017
+        ./examples/tm_classification_timvx -m ./tengine_test_data/squeezenet_uint8.tmfile -i ./images/cat.jpg -g 227,227, -s 0.017,0.017,0.017
+    - name: lcov-collect
+      run: |
+        cd build
+        lcov -d ./src -c -o lcov.info
+        lcov -r lcov.info '*3rdparty*' -o lcov.info
+        lcov -r lcov.info '*/src/dev/cpu/*' -o lcov.info
+        lcov -r lcov.info '*/src/dev/tim-vx/src/*' -o lcov.info
+        lcov -r lcov.info '/usr/*' -o lcov.info
+        lcov --list lcov.info        
     - name: codecov
       uses: codecov/codecov-action@v1.0.11
       with:

--- a/.github/workflows/workflows.yml
+++ b/.github/workflows/workflows.yml
@@ -133,18 +133,27 @@ jobs:
         ../tests/test_arm64.sh
         
 
-  linux-gcc-x86-avx2:
+  linux-gcc-x86-timvx-simulator:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v1
     - name: update
       run: sudo apt-get update
     - name: protobuf
-      run: sudo apt-get install libopencv-dev    
+      run: sudo apt-get install libopencv-dev
+    - name: tim-vx
+      run: |
+        git clone https://github.com/VeriSilicon/TIM-VX.git
+        mkdir -p ./3rdparty/tim-vx/lib/x86_64
+        mkdir -p ./3rdparty/tim-vx/include
+        cp -rf ./TIM-VX/include/*    ./3rdparty/tim-vx/include/
+        cp -rf ./TIM-VX/src    ./src/dev/tim-vx/
+        cp -rf ./TIM-VX/prebuilt-sdk/x86_64_linux/include/*    ./3rdparty/tim-vx/include/
+        cp -rf ./TIM-VX/prebuilt-sdk/x86_64_linux/lib/*    ./3rdparty/tim-vx/lib/x86_64/
     - name: configure
-      run: mkdir build && cd build && cmake -DTENGINE_AVX2=ON ..
+      run: mkdir build && cd build && cmake -DTENGINE_ENABLE_TIM_VX=ON -DTENGINE_ENABLE_TIM_VX_INTEGRATION=ON ..
     - name: build
-      run: cmake --build build -j 2      
+      run: cmake --build build -j 2
 
 
   android-armv7-a:

--- a/doc/npu_tim-vx_user_manual.md
+++ b/doc/npu_tim-vx_user_manual.md
@@ -1,24 +1,45 @@
-# Tengine Lite VeriSilicon TIM-VX User Manual
+# Tengine Lite with VeriSilicon TIM-VX User Manual
 
-## Brief
+## 1. Brief
 
 TIM-VX is a software integration module provided by VeriSilicon to facilitate deployment of Neural-Networks on OpenVX enabled ML accelerators.
 
 Tengine Lite has supported to integrate with TIM-VX Library of Verisilicon to inference CNN by Khadas VIM3(Amlogic A311D).
 
-## Build
+## 2. How to Build
 
-For some special reasons, only supported on Khadas VIM3 to work the following steps, currently.
+For some special reasons, only supported on Khadas VIM3 or x86_64 simulator to work the following steps, currently.
 
-### TIM-VX NPU Library
-
-#### Download Source code of TIM-VX 
+##### Download Source code of TIM-VX 
 
 ```bash
 $ git clone https://github.com/VeriSilicon/TIM-VX.git
 ```
 
-#### Download prebuild-sdk of A311D
+##### Download Tengine Lite
+
+```bash
+$ git clone https://github.com/OAID/Tengine.git tengine-lite
+$ cd tengine-lite
+```
+
+#### 2.1 Prepare for x86_64 simulator platform
+
+##### Create depend files
+
+```bash
+$ cd <tengine-lite-root-dir>
+$ mkdir -p ./3rdparty/tim-vx/lib/x86_64
+$ mkdir -p ./3rdparty/tim-vx/include
+$ cp -rf ../TIM-VX/include/*    ./3rdparty/tim-vx/include/
+$ cp -rf ../TIM-VX/src    ./src/dev/tim-vx/
+$ cp -rf ../TIM-VX/prebuilt-sdk/x86_64_linux/include/*    ./3rdparty/tim-vx/include/
+$ cp -rf ../TIM-VX/prebuilt-sdk/x86_64_linux/lib/*    ./3rdparty/tim-vx/lib/x86_64/
+```
+
+#### 2.2 Prepare for on Khadas VIM3 platform
+
+##### Download prebuild-sdk of A311D
 
 ```bash
 $ wget -c https://github.com/VeriSilicon/TIM-VX/releases/download/v1.1.28/aarch64_A311D_D312513_A294074_R311680_T312233_O312045.tgz
@@ -26,16 +47,7 @@ $ tar zxvf aarch64_A311D_D312513_A294074_R311680_T312233_O312045.tgz
 $ mv aarch64_A311D_D312513_A294074_R311680_T312233_O312045 prebuild-sdk-a311d
 ```
 
-### Tengine Lite
-
-#### Download Tengine Lite
-
-```bash
-$ git clone https://github.com/OAID/Tengine.git tengine-lite
-$ cd tengine-lite
-```
-
-#### Create depend files
+##### Create depend files
 
 ```bash
 $ cd <tengine-lite-root-dir>
@@ -44,10 +56,10 @@ $ mkdir -p ./3rdparty/tim-vx/include
 $ cp -rf ../TIM-VX/include/*    ./3rdparty/tim-vx/include/
 $ cp -rf ../TIM-VX/src    ./src/dev/tim-vx/
 $ cp -rf ../prebuild-sdk-a311d/include/*    ./3rdparty/tim-vx/include/
-$ cp -rf ../prebuild-sdk-a311d/lib/*.so    ./3rdparty/tim-vx/lib/aarch64/
+$ cp -rf ../prebuild-sdk-a311d/lib/*    ./3rdparty/tim-vx/lib/aarch64/
 ```
 
-#### Build Tengine Lite
+#### 2.3 Build Tengine Lite with TIM-VX
 
 ```bash
 $ mkdir build && cd build
@@ -56,17 +68,19 @@ $ make -j4
 $ make install
 ```
 
-## Demo
+## 3. Demo
 
-#### Depned librarys
+#### 3.1 Depned librarys
 
 ```
 3rdparty/tim-vx/lib/
-├── libOpenVX.so.1 
-├── libVSC.so
-├── libGAL.so
 ├── libArchModelSw.so
-└── libNNArchPerf.so 
+├── libCLC.so
+├── libGAL.so
+├── libNNArchPerf.so
+├── libOpenVX.so
+├── libOpenVXU.so
+└── libVSC.so
 
 build-tim-vx-arm64/install/lib/
 └── libtengine-lite.so
@@ -74,7 +88,7 @@ build-tim-vx-arm64/install/lib/
 
 On the Khadas VIM3, it need to replace those libraries in the /lib/ path
 
-#### Set uint8 Inference mode
+#### 3.2 Set uint8 Inference mode
 
 TIM-VX Library needs the uint8 network model
 
@@ -87,7 +101,7 @@ opt.precision = TENGINE_MODE_UINT8;
 opt.affinity = 0;
 ```
 
-#### Result
+#### 3.3 Result
 
 ```
 [khadas@Khadas tengine-lite]# ./tm_classification_timvx -m squeezenet_uint8.tmfile -i cat.jpg -r 1 -s 0.017,0.017,0.017 -r 10

--- a/examples/tm_classification_timvx.c
+++ b/examples/tm_classification_timvx.c
@@ -80,7 +80,7 @@ int tengine_classify(const char* model_file, const char* image_file, int img_h, 
     }
     fprintf(stderr, "tengine-lite library version: %s\n", get_tengine_version());
 
-    /* create arm acl backend */
+    /* create VeriSilicon TIM-VX backend */
     context_t timvx_context = create_context("timvx", 1);
     int rtt = add_context_device(timvx_context, "TIMVX");
     if (0 > rtt)

--- a/examples/tm_mobilenet_ssd_uint8.cpp
+++ b/examples/tm_mobilenet_ssd_uint8.cpp
@@ -274,8 +274,6 @@ int main(int argc, char* argv[])
     /* release tengine */
     free(output_data);
     free(input_data);
-    release_graph_tensor(input_tensor);
-    release_graph_tensor(output_tensor);
     postrun_graph(graph);
     destroy_graph(graph);
     release_tengine();


### PR DESCRIPTION
- add TIM-VX x86_64 simulator example;
- add TIM-VX x86_64 simulator into ci and codecov.