### PR TITLE
fix a typo bug in wait_graph

### DIFF
--- a/src/lib/tengine_c_api.c
+++ b/src/lib/tengine_c_api.c
@@ -1100,7 +1100,7 @@ int wait_graph(graph_t graph, int try_wait)
     struct exec_context* context = get_ir_graph_context(ir_graph);
     struct exec_scheduler* scheduler = context->scheduler;
 
-    if (ir_graph->status != GRAPH_STAT_RUNNING || ir_graph->status != GRAPH_STAT_READY)
+    if (ir_graph->status != GRAPH_STAT_RUNNING && ir_graph->status != GRAPH_STAT_READY)
     {
         set_tengine_errno(EINVAL);
         return -1;


### PR DESCRIPTION
The old code will always run into `set_tengine_errno(EINVAL);`