### PR TITLE
fix OpenMP parameter

### DIFF
--- a/source/device/cpu/op/conv/risc-v/lp64dv/conv_dw_kernel_rv64.c
+++ b/source/device/cpu/op/conv/risc-v/lp64dv/conv_dw_kernel_rv64.c
@@ -321,7 +321,7 @@ static void convdw5x5s1(float* output, float* input, float* _kernel, float* _bia
     const int group = channel;
     const float* kernel = _kernel;    
 
-#pragma omp parallel for num_threads(opt.num_threads)
+#pragma omp parallel for num_threads(num_thread)
     for (int g = 0; g < group; g++)
     {
         float* out = output + g * c_step_out;
@@ -513,7 +513,7 @@ static void convdw5x5s2(float* output, float* input, float* _kernel, float* _bia
     const int tailstep = w - 2 * outw + w;
     const float* kernel = _kernel;
 
-#pragma omp parallel for num_threads(opt.num_threads)
+#pragma omp parallel for num_threads(num_thread)
     for (int g = 0; g < group; g++)
     {
         float* out = output + g * c_step_out;


### PR DESCRIPTION
尽管文件"toolchain/rv64-c906.toolchain.cmake"忽略了OpenMP pragma，不过这里的opt.num_threads确实有问题，该文件中并没有定义opt。
我看到ncnn里面定义了opt所以它用了opt.num_threads
第一次写PR，若有错误恳请指正