### PR TITLE
fix example error

### DIFF
--- a/examples/tm_classification_trt.cpp
+++ b/examples/tm_classification_trt.cpp
@@ -62,7 +62,7 @@ int tengine_classify(const char* model_file, const char* image_file, int img_h, 
 	
     /* create NVIDIA TensorRT backend */
     context_t trt_context = create_context("trt", 1);
-    int rtt = add_context_device(trt_context, "TRT");
+    int rtt = add_context_device(trt_context, "TensorRT");
     if (0 > rtt)
     {
         fprintf(stderr, " add_context_device NV TensorRT DEVICE failed.\n");

--- a/source/device/tim-vx/timvx_executor.cc
+++ b/source/device/tim-vx/timvx_executor.cc
@@ -83,7 +83,7 @@ void VXEngine::VXTensorMap(struct graph* ir_graph, int ir_tensor_idx, int spec_t
                 datatype = tim::vx::DataType::INT32;
                 break;
             default:
-                TLOG_INFO("FP32 tensor: Tensor_name(%s) tensor_index(%d) .\n",ir_tensor->name, ir_tensor->index);
+                TLOG_ERR("Tensor: Tensor_name(%s) tensor_index(%d) tensor_data_type(%d) .\n",ir_tensor->name, ir_tensor->index, ir_tensor->data_type);
                 break;
         }
 

--- a/source/device/tim-vx/timvx_executor.cc
+++ b/source/device/tim-vx/timvx_executor.cc
@@ -83,7 +83,7 @@ void VXEngine::VXTensorMap(struct graph* ir_graph, int ir_tensor_idx, int spec_t
                 datatype = tim::vx::DataType::INT32;
                 break;
             default:
-                TLOG_ERR("Tengine: TIM-VX is not supported date type(%d).\n",ir_tensor->data_type);
+                TLOG_INFO("FP32 tensor: Tensor_name(%s) tensor_index(%d) .\n",ir_tensor->name, ir_tensor->index);
                 break;
         }
 


### PR DESCRIPTION
1.replace "TRT"  with "TensorRT" in  tm_classification_trt.cpp add_context_device name.
2.TIM-VX print not support data_type.