### PR TITLE
[operator] prototype/pad: fix unexpected output tensor dim 0

### DIFF
--- a/source/operator/prototype/pad.c
+++ b/source/operator/prototype/pad.c
@@ -51,7 +51,7 @@ static int infer_shape(ir_node_t* node)
     }
     else
     {
-        return 0;
+        return -1;
     }
 
     set_ir_tensor_shape(output, dims, input->dim_num);


### PR DESCRIPTION
As title, when all pad_param->pad_i_h/w (i=0,1) are -1, this fun return 0 as shape infer OK.
However, the output tensor's dim is still 0, which causes the input tensor's height=-1 and width=-1 for the next node.

Reproduce step:
1. export official https://github.com/ultralytics/yolov3/releases/download/v9.5.0/yolov3-tiny.pt to yolov3-tiny.onnx;
2. convert the yolov3-tiny.onnx to yolov3-tiny.tmfile;
3. run_graph