### PR TITLE
[examples] bug fix: unexpected redefinition of get_current_time

### DIFF
--- a/examples/common/common.h
+++ b/examples/common/common.h
@@ -47,7 +47,7 @@
 #endif    // _WIN32
 
 #ifdef _WIN32
-double get_current_time()
+static double get_current_time()
 {
     LARGE_INTEGER freq;
     LARGE_INTEGER pc;
@@ -58,7 +58,7 @@ double get_current_time()
 }
 #else    // _WIN32
 
-double get_current_time()
+static double get_current_time()
 {
     struct timeval tv;
     gettimeofday(&tv, NULL);
@@ -67,7 +67,7 @@ double get_current_time()
 }
 #endif    // _WIN32
 
-void split(float* array, char* str, const char* del)
+static void split(float* array, char* str, const char* del)
 {
     char* s = NULL;
     s = strtok(str, del);


### PR DESCRIPTION
As title, for some reason, I've to build all examples with the static library.
Then, the unexpected redefinition error happened(1st definition is in source/device/cpu/cpu_dump.c).

Reproduce steps:

1. update TARGET_LINK_LIBRARIES with ${CMAKE_PROJECT_NAME}-static
    --- a/examples/CMakeLists.txt
    +++ b/examples/CMakeLists.txt
    @@ -33,7 +33,7 @@ FUNCTION (TENGINE_EXAMPLE name file)
         TARGET_INCLUDE_DIRECTORIES (${name} PRIVATE "${CMAKE_CURRENT_BINARY_DIR}")
         TARGET_INCLUDE_DIRECTORIES (${name} PRIVATE "${PROJECT_SOURCE_DIR}/examples/common")

    \-    TARGET_LINK_LIBRARIES (${name} PRIVATE ${CMAKE_PROJECT_NAME})
    \+    TARGET_LINK_LIBRARIES (${name} PRIVATE ${CMAKE_PROJECT_NAME}-static)

2. try "make" again