### PR TITLE
Eltwise TIMVX constant tensor support.

### DIFF
--- a/source/device/tim-vx/op/timvx_eltwise.cc
+++ b/source/device/tim-vx/op/timvx_eltwise.cc
@@ -35,37 +35,71 @@ bool VXEngine::AddEltwiseNode(struct node* ir_node)
 {
     struct graph* ir_graph = ir_node->graph;
 
-    std::vector<std::shared_ptr<tim::vx::Tensor> > add_in_tensor(ir_node->input_num);
-    for (int i = 0; i < ir_node->input_num; i++)
-    {
-        struct tensor* input_tensor = get_ir_graph_tensor(ir_graph, ir_node->input_tensors[i]);
-        add_in_tensor[i] = this->vx_tensor_map[input_tensor->index];
-    }
-    struct tensor* output_tensor = get_ir_graph_tensor(ir_graph, ir_node->output_tensors[0]);
+    struct tensor* const_tensor = get_ir_graph_tensor(ir_graph, ir_node->input_tensors[1]);
 
-    eltwise_param* param = (eltwise_param*)ir_node->op.param_mem;
-
-    switch (param->type)
+    if (const_tensor->tensor_type == TENSOR_TYPE_CONST && const_tensor->data_type == TENGINE_DT_FP32)
     {
-        case ELT_SUM:
+        float* const_fp32 = ( float* )get_tensor_buffer(const_tensor);
+        int const_size = get_tensor_buffer_size(const_tensor) / sizeof(float) ;
+        if (const_size == 1 && const_fp32[0] == 0)
         {
-            auto eltsum = graph->CreateOperation<tim::vx::ops::Add>();
-            (*eltsum)
-                .BindInputs(add_in_tensor)
-                .BindOutputs({ this->vx_tensor_map[output_tensor->index] });
-            break;
+            struct tensor* input_tensor = get_ir_graph_tensor(ir_graph, ir_node->input_tensors[0]);
+            struct tensor* output_tensor = get_ir_graph_tensor(ir_graph, ir_node->output_tensors[0]);
+            std::vector<uint32_t> perm;
+            for (int i = output_tensor->dim_num - 1; i >= 0; i--)
+            {
+                perm.push_back(output_tensor->dims[i]);
+            }
+
+            auto reshape = graph->CreateOperation<tim::vx::ops::Reshape>(perm);
+            vx_node_map[ir_node->index] = reshape;
+
+            (*reshape)
+                    .BindInputs({ this->vx_tensor_map[input_tensor->index] })
+                    .BindOutputs({ this->vx_tensor_map[output_tensor->index] });
         }
-        case ELT_SUB:
+        else
         {
-            auto eltsub = graph->CreateOperation<tim::vx::ops::Sub>();
-            (*eltsub)
-                .BindInputs(add_in_tensor)
-                .BindOutputs({ this->vx_tensor_map[output_tensor->index] });
-            break;
+            //to do
         }
-        default:
-            break;
+
     }
+    else
+    {
+        std::vector<std::shared_ptr<tim::vx::Tensor> > add_in_tensor(ir_node->input_num);
+        for (int i = 0; i < ir_node->input_num; i++)
+        {
+            struct tensor* input_tensor = get_ir_graph_tensor(ir_graph, ir_node->input_tensors[i]);
+            add_in_tensor[i] = this->vx_tensor_map[input_tensor->index];
+        }
+        struct tensor* output_tensor = get_ir_graph_tensor(ir_graph, ir_node->output_tensors[0]);
+
+        eltwise_param* param = (eltwise_param*)ir_node->op.param_mem;
+
+        switch (param->type)
+        {
+            case ELT_SUM:
+            {
+                auto eltsum = graph->CreateOperation<tim::vx::ops::Add>();
+                (*eltsum)
+                        .BindInputs(add_in_tensor)
+                        .BindOutputs({ this->vx_tensor_map[output_tensor->index] });
+                break;
+            }
+            case ELT_SUB:
+            {
+                auto eltsub = graph->CreateOperation<tim::vx::ops::Sub>();
+                (*eltsub)
+                        .BindInputs(add_in_tensor)
+                        .BindOutputs({ this->vx_tensor_map[output_tensor->index] });
+                break;
+            }
+            default:
+                break;
+        }
+    }
+
+
 
     return 0;
 }


### PR DESCRIPTION
To fix the error if TIMVX is in the RELEASE version.

E [op_check_add:369]Inputs/Outputs data type not support: ASYM UINT8, ASYM FLOAT16, ASYM UINT8
E [setup_node:456]Check node[79] ADD fail
Tengine Fatal: Pre-run subgraph(0) on TIMVX failed.
Tengine: Scheduler(sync) prerun failed.

Code from NPU xiaoge...