### PR TITLE
[examples] fix param order for api 'resize_image'

### DIFF
--- a/examples/common/tengine_operations.h
+++ b/examples/common/tengine_operations.h
@@ -156,10 +156,10 @@ image imread2tflite(image im, int img_w, int img_h, float* means, float* scale);
 /*
  * resize the image, and then return the image type
  * @param [in] im : input image
- * @param [in] h: resized height
  * @param [in] w: resied width
+ * @param [in] h: resized height
  */
-image resize_image(image im, int h, int w);
+image resize_image(image im, int w, int h);
 
 /**
  * load image, support JPG, PNG, BMP, TGA formats


### PR DESCRIPTION
as title, and one can compare the function declaration and implement:
https://github.com/OAID/Tengine/blob/850d570c65d2285c3c691660f4ffe7c3c18e6a9d/examples/common/tengine_operations.h#L162
https://github.com/OAID/Tengine/blob/850d570c65d2285c3c691660f4ffe7c3c18e6a9d/examples/common/tengine_operations.c#L162