### PR TITLE
[tools] optimize/nanodet_m: add new option --softmax

### DIFF
--- a/tools/optimize/.gitignore
+++ b/tools/optimize/.gitignore
@@ -1,0 +1,2 @@
+# Onnx model files
+*.onnx


### PR DESCRIPTION
It's not necessary to add additional softmax node in the end of all distance prediction branches. (my fault)
Actually, it could hurt the runtime performance. So I add a new option to disable the unnecessary optimization steps.
One can also delete the nanodet_m-opt.py script directly, but it still could be a good example about how to edit an exported onnx model, I think.