### PR TITLE
fix: remove concat_kernel_ref_fp32.c shadowed variables

### DIFF
--- a/source/device/cpu/op/concat/concat_kernel_ref_fp32.c
+++ b/source/device/cpu/op/concat/concat_kernel_ref_fp32.c
@@ -64,7 +64,6 @@ int ref_concat_fp32(struct graph* ir_graph, struct node* ir_node, int axis)
         for (int num = 0; num < ir_node->input_num; num++)
         {
             struct tensor* input_tensor = get_ir_graph_tensor(ir_graph, ir_node->input_tensors[num]);
-            struct tensor* output_tensor = get_ir_graph_tensor(ir_graph, ir_node->output_tensors[0]);
 
             int size = input_tensor->elem_num;
 
@@ -87,7 +86,6 @@ int ref_concat_fp32(struct graph* ir_graph, struct node* ir_node, int axis)
         for (int num = 0; num < ir_node->input_num; num++)
         {
             struct tensor* input_tensor  = get_ir_graph_tensor(ir_graph, ir_node->input_tensors[num]);
-            struct tensor* output_tensor = get_ir_graph_tensor(ir_graph, ir_node->output_tensors[0]);
 
             int size = input_tensor->elem_num;
 


### PR DESCRIPTION
Hi, Tengine Team

This PR fix the fatal warning "shadowed variables".
