### PR TITLE
fix: resolve shadowed variables in region_ref.c

### DIFF
--- a/source/device/cpu/op/region/region_ref.c
+++ b/source/device/cpu/op/region/region_ref.c
@@ -117,13 +117,13 @@ static int ref_region_fp32(struct tensor* input_tensor, struct tensor* output_te
 
     for (int b = 0; b < batch; b++)
     {
-        for (int n = 0; n < num_box; n++)
+        for (int ni = 0; ni < num_box; ni++)
         {
-            int index = entry_index(b, n * hw, 0, hw, chw, num_class);
+            int index = entry_index(b, ni * hw, 0, hw, chw, num_class);
             logit_activate_array(out_data + index, 2 * hw);
-            index = entry_index(b, n * hw, coords, hw, chw, num_class);
+            index = entry_index(b, ni * hw, coords, hw, chw, num_class);
             logit_activate_array(out_data + index, hw);
-            index = entry_index(b, n * hw, coords + 1, hw, chw, num_class);
+            index = entry_index(b, ni * hw, coords + 1, hw, chw, num_class);
         }
     }
 


### PR DESCRIPTION
Hi Tengine Team

This PR fix the fatal warning "shadowed variables" in region_ref.c.