### PR TITLE
cmake val missing in quant tool compile tutorial.

### DIFF
--- a/tools/quantize/README.md
+++ b/tools/quantize/README.md
@@ -17,7 +17,7 @@ git clone https://github.com/OAID/Tengine.git  tengine-lite
 cd tengine-lite
 mkdir build 
 cd build
-cmake -DTENGINE_BUILD_QUANT_TOOL ..
+cmake -DTENGINE_BUILD_QUANT_TOOL=ON ..
 make && make install
 ```
 


### PR DESCRIPTION
```bash
root@1d0954a2d18b:~/tengine-lite/build# cmake -DTENGINE_BUILD_QUANT_TOOL ..
CMake Error: Parse error in command line argument: TENGINE_BUILD_QUANT_TOOL
 Should be: VAR:type=value

CMake Error: Run 'cmake --help' for all supported options.
```