### PR TITLE
fix interp align_corner bug

### DIFF
--- a/source/device/cpu/op/interp/cortex-a/interp_kernel_arm.c
+++ b/source/device/cpu/op/interp/cortex-a/interp_kernel_arm.c
@@ -47,7 +47,7 @@ static void linear_coeffs(int w, int outw, int* xofs, float* alpha, int align_co
         {
             fx = (float)((dx)*scale);
         }
-        
+
         int sx = floor(fx);
         fx -= sx;
 

--- a/source/device/cpu/op/interp/cortex-a/interp_kernel_arm.c
+++ b/source/device/cpu/op/interp/cortex-a/interp_kernel_arm.c
@@ -517,8 +517,8 @@ int interp_run(struct tensor* output_tensor, struct tensor* input_tensor, struct
         float* alpha = (float*)(buf + out_w + out_h);            // new float[ow * 2];
         float* beta = (float*)(buf + out_w + out_h + out_w * 2); // new float[oh * 2];
 
-        linear_coeffs(in_w, out_w, xofs, alpha, param->align_corner);
-        linear_coeffs(in_h, out_h, yofs, beta, param->align_corner);
+        linear_coeffs(in_w, out_w, xofs, alpha, interp_param->align_corner);
+        linear_coeffs(in_h, out_h, yofs, beta, interp_param->align_corner);
 
 #pragma omp parallel for num_threads(num_thread)
         for (int q = 0; q < in_c; ++q)

--- a/source/device/cpu/op/interp/cortex-a/interp_kernel_arm.c
+++ b/source/device/cpu/op/interp/cortex-a/interp_kernel_arm.c
@@ -32,13 +32,22 @@
 
 #define MIN(a, b) ((a) < (b) ? (a) : (b))
 
-static void linear_coeffs(int w, int outw, int* xofs, float* alpha)
+static void linear_coeffs(int w, int outw, int* xofs, float* alpha, int align_corner)
 {
     double scale = (double)w / outw;
 
+    if (align_corner)
+    {
+        scale = (double)(w - 1) / (outw - 1);
+    }
     for (int dx = 0; dx < outw; dx++)
     {
-        float fx = (float)((dx)*scale);
+        float fx = (float)((dx + 0.5) * scale - 0.5);
+        if (align_corner)
+        {
+            fx = (float)((dx)*scale);
+        }
+        
         int sx = floor(fx);
         fx -= sx;
 
@@ -508,8 +517,8 @@ int interp_run(struct tensor* output_tensor, struct tensor* input_tensor, struct
         float* alpha = (float*)(buf + out_w + out_h);            // new float[ow * 2];
         float* beta = (float*)(buf + out_w + out_h + out_w * 2); // new float[oh * 2];
 
-        linear_coeffs(in_w, out_w, xofs, alpha);
-        linear_coeffs(in_h, out_h, yofs, beta);
+        linear_coeffs(in_w, out_w, xofs, alpha, param->align_corner);
+        linear_coeffs(in_h, out_h, yofs, beta, param->align_corner);
 
 #pragma omp parallel for num_threads(num_thread)
         for (int q = 0; q < in_c; ++q)

--- a/source/device/cpu/op/interp/interp_ref.c
+++ b/source/device/cpu/op/interp/interp_ref.c
@@ -51,7 +51,7 @@ void linear_coeffs(int w, int outw, int* xofs, float* alpha, int align_corner)
         float fx = (float)((dx + 0.5) * scale - 0.5);
         if (align_corner)
         {
-            float fx = (float)((dx)*scale);
+            fx = (float)((dx)*scale);
         }
 
         int sx = floor(fx);

--- a/source/device/cpu/op/interp/interp_ref.c
+++ b/source/device/cpu/op/interp/interp_ref.c
@@ -53,7 +53,7 @@ void linear_coeffs(int w, int outw, int* xofs, float* alpha, int align_corner)
         {
             float fx = (float)((dx)*scale);
         }
-        
+
         int sx = floor(fx);
         fx -= sx;
 

--- a/source/device/cpu/op/interp/interp_ref.c
+++ b/source/device/cpu/op/interp/interp_ref.c
@@ -39,13 +39,21 @@
 
 #define INTERP_MIN(a, b) ((a) < (b) ? (a) : (b))
 
-void linear_coeffs(int w, int outw, int* xofs, float* alpha)
+void linear_coeffs(int w, int outw, int* xofs, float* alpha, int align_corner)
 {
     double scale = (double)w / outw;
-
+    if (align_corner)
+    {
+        scale = (double)(w - 1) / (outw - 1);
+    }
     for (int dx = 0; dx < outw; dx++)
     {
-        float fx = (float)((dx)*scale);
+        float fx = (float)((dx + 0.5) * scale - 0.5);
+        if (align_corner)
+        {
+            float fx = (float)((dx)*scale);
+        }
+        
         int sx = floor(fx);
         fx -= sx;
 
@@ -222,8 +230,8 @@ int ref_interp_fp32(struct tensor* input_tensor, struct tensor* output_tensor, s
         float* alpha = (float*)(buf + param->output_width + param->output_height);                          //new float[ow * 2];
         float* beta = (float*)(buf + param->output_width + param->output_height + param->output_width * 2); //new float[oh * 2];
 
-        linear_coeffs(in_w, out_w, xofs, alpha);
-        linear_coeffs(in_h, out_h, yofs, beta);
+        linear_coeffs(in_w, out_w, xofs, alpha, param->align_corner);
+        linear_coeffs(in_h, out_h, yofs, beta, param->align_corner);
 
         for (int q = 0; q < channel; ++q)
         {
@@ -316,8 +324,8 @@ int ref_interp_uint8(struct tensor* input_tensor, struct tensor* output_tensor, 
         float* alpha = (float*)(buf + param->output_width + param->output_height);                          //new float[ow * 2];
         float* beta = (float*)(buf + param->output_width + param->output_height + param->output_width * 2); //new float[oh * 2];
 
-        linear_coeffs(in_w, out_w, xofs, alpha);
-        linear_coeffs(in_h, out_h, yofs, beta);
+        linear_coeffs(in_w, out_w, xofs, alpha, param->align_corner);
+        linear_coeffs(in_h, out_h, yofs, beta, param->align_corner);
 
         for (int q = 0; q < channel; ++q)
         {

--- a/source/operator/prototype/interp.c
+++ b/source/operator/prototype/interp.c
@@ -86,6 +86,7 @@ static int init_op(struct op* op)
     interp_param->output_width = 0;
     interp_param->height_scale = 1.f;
     interp_param->width_scale = 1.f;
+    interp_param->align_corner = 1;
 
     op->param_mem = interp_param;
     op->param_size = sizeof(struct interp_param);

--- a/source/operator/prototype/interp.c
+++ b/source/operator/prototype/interp.c
@@ -86,7 +86,7 @@ static int init_op(struct op* op)
     interp_param->output_width = 0;
     interp_param->height_scale = 1.f;
     interp_param->width_scale = 1.f;
-    interp_param->align_corner = 1;
+    interp_param->align_corner = 0;
 
     op->param_mem = interp_param;
     op->param_size = sizeof(struct interp_param);

--- a/source/operator/prototype/interp_param.h
+++ b/source/operator/prototype/interp_param.h
@@ -32,6 +32,7 @@ struct interp_param
     int output_width;
     float height_scale;
     float width_scale;
+    int align_corner;
 };
 
 #endif

--- a/source/serializer/tmfile/op/tm2_interp.c
+++ b/source/serializer/tmfile/op/tm2_interp.c
@@ -52,6 +52,7 @@ static int tm2_load_interp(struct graph* ir_graph, struct node* ir_node, const T
     param->height_scale = tm_param->height_scale;
     param->output_width = tm_param->output_width;
     param->output_height = tm_param->output_height;
+    param->align_corner = tm_param->align_corner;
 
     return 0;
 }

--- a/source/serializer/tmfile/tm2_format.h
+++ b/source/serializer/tmfile/tm2_format.h
@@ -899,6 +899,7 @@ typedef struct
     float height_scale;
     int32_t output_width;
     int32_t output_height;
+    int32_t align_corner;
 } TM2_InterpParam;
 
 typedef struct

--- a/tools/convert_tool/onnx/onnx2tengine.cpp
+++ b/tools/convert_tool/onnx/onnx2tengine.cpp
@@ -2132,7 +2132,7 @@ int load_resize(ir_graph_t* graph, ir_node_t* node, const onnx::NodeProto& onnx_
     struct interp_param* interp_param = (struct interp_param*)node->op.param_mem;
     interp_param->height_scale = 0;
     interp_param->width_scale = 0;
-    
+
     for (int k = 0; k < onnx_node.attribute_size(); k++)
     {
         const onnx::AttributeProto& attr = onnx_node.attribute(k);

--- a/tools/convert_tool/onnx/onnx2tengine.cpp
+++ b/tools/convert_tool/onnx/onnx2tengine.cpp
@@ -2132,7 +2132,16 @@ int load_resize(ir_graph_t* graph, ir_node_t* node, const onnx::NodeProto& onnx_
     struct interp_param* interp_param = (struct interp_param*)node->op.param_mem;
     interp_param->height_scale = 0;
     interp_param->width_scale = 0;
-
+    
+    for (int k = 0; k < onnx_node.attribute_size(); k++)
+    {
+        const onnx::AttributeProto& attr = onnx_node.attribute(k);
+        if (attr.name() == "coordinate_transformation_mode")
+        {
+            if (attr.s() == "align_corners")
+                interp_param->align_corner = 1;
+        }
+    }
     if (onnx_node.input_size() == 1)
     {
         for (int k = 0; k < onnx_node.attribute_size(); k++)

--- a/tools/convert_tool/onnx/onnx2tengine.cpp
+++ b/tools/convert_tool/onnx/onnx2tengine.cpp
@@ -1283,11 +1283,8 @@ int load_interp(ir_graph_t* graph, ir_node_t* node, const onnx::NodeProto& onnx_
             interp_param->height_scale = data[2];
             interp_param->width_scale = data[3];
         }
-        if (mode == "nearest")
-        {
-            interp_param->resize_type = 1;
-        }
-        else if (mode == "bilinear" || mode == "linear")
+
+        if (mode == "bilinear" || mode == "linear")
         {
             interp_param->resize_type = 2;
         }

--- a/tools/save_graph/tm2_op_save.cpp
+++ b/tools/save_graph/tm2_op_save.cpp
@@ -1110,6 +1110,7 @@ tm_uoffset_t SaveTmInterpOp(void* const start_ptr, tm_uoffset_t* cur_pos, ir_nod
     tm_param.output_width = p->output_width;
     tm_param.resize_type = p->resize_type;
     tm_param.width_scale = p->width_scale;
+    tm_param.align_corner = p->align_corner;
 
     TM2_Operator tm_op;
     SetTmOperator(&tm_op, TM2_OPTYPE_INTERP, WriteTmObject(start_ptr, cur_pos, &tm_param, sizeof(TM2_InterpParam)));


### PR DESCRIPTION
原有tengine转换的model中如果存在interp参数是linear，但是align_corner=False，输出结果是有问题的，比如nanodet.
https://github.com/onnx/onnx/blob/master/docs/Changelog.md#Resize-11