### PR TITLE
fix pytengine bug

### DIFF
--- a/pytengine/tengine/tensor.py
+++ b/pytengine/tengine/tensor.py
@@ -137,6 +137,13 @@ class Tensor(object):
         res = _LIB.get_tensor_buffer(ctypes.c_void_p(self.tensor))
         return res[:size]
 
+    def ascontiguousarray(self,value):
+        if self.dtype.enum == 2:
+            value = np.ascontiguousarray(value.astype(np.int8))
+            value = value.astype(np.int8)
+        else:
+            value = np.ascontiguousarray(value)
+        return value
     @buf.setter
     def buf(self, value):
         """
@@ -150,16 +157,10 @@ class Tensor(object):
             ctypes.c_int,
         ]
         value_bytes = ctypes.sizeof(Tengine_ctype[self.dtype.enum])
-        b = np.copy(value)
         print("self.dtype.enum:", self.dtype.enum)
-        if self.dtype.enum == 2:
-            value_c = np.ascontiguousarray(b.astype(np.int8))
-            value_c = value_c.astype(np.int8)
-        else:
-            value_c = np.ascontiguousarray(b)
         check_call(
             _LIB.set_tensor_buffer(
-                self.tensor, np.ctypeslib.as_ctypes(value_c), value.size * value_bytes
+                ctypes.c_void_p(self.tensor), np.ctypeslib.as_ctypes(value), value.size * value_bytes
             )
         )
 
@@ -197,7 +198,7 @@ class Tensor(object):
                     ctypes.c_void_p(self.tensor),
                     ctypes.cast(c_data, ctypes.c_void_p),
                     ctypes.sizeof(ctypes.c_char) * self._data[1],
-                )
+                    )
             )
             return ctypes2buffer(
                 ctypes.cast(c_data, ctypes.POINTER(ctypes.c_char)), self._data[1]
@@ -252,7 +253,7 @@ class Tensor(object):
                             ctypes.c_void_p(self.tensor),
                             ctypes.cast(c_data, ctypes.POINTER(ctypes.c_int)),
                             ctypes.sizeof(ctypes.c_int) * size,
-                        )
+                            )
                     )
                 elif type(data[0]) == type(0.0):
                     self._data = [ctypes.c_float, size]
@@ -262,7 +263,7 @@ class Tensor(object):
                             ctypes.c_void_p(self.tensor),
                             ctypes.cast(c_data, ctypes.POINTER(ctypes.c_float)),
                             ctypes.sizeof(ctypes.c_float) * size,
-                        )
+                            )
                     )
                 else:
                     return -1

--- a/pytengine/tengine/tensor.py
+++ b/pytengine/tengine/tensor.py
@@ -198,7 +198,7 @@ class Tensor(object):
                     ctypes.c_void_p(self.tensor),
                     ctypes.cast(c_data, ctypes.c_void_p),
                     ctypes.sizeof(ctypes.c_char) * self._data[1],
-                    )
+                )
             )
             return ctypes2buffer(
                 ctypes.cast(c_data, ctypes.POINTER(ctypes.c_char)), self._data[1]
@@ -253,7 +253,7 @@ class Tensor(object):
                             ctypes.c_void_p(self.tensor),
                             ctypes.cast(c_data, ctypes.POINTER(ctypes.c_int)),
                             ctypes.sizeof(ctypes.c_int) * size,
-                            )
+                        )
                     )
                 elif type(data[0]) == type(0.0):
                     self._data = [ctypes.c_float, size]
@@ -263,7 +263,7 @@ class Tensor(object):
                             ctypes.c_void_p(self.tensor),
                             ctypes.cast(c_data, ctypes.POINTER(ctypes.c_float)),
                             ctypes.sizeof(ctypes.c_float) * size,
-                            )
+                        )
                     )
                 else:
                     return -1


### PR DESCRIPTION
@buf.setter changes the value's address ,  so the memory would point  unkonw address which cause data of input tensor mismatch  with the data of numpy in python function .
