### PR TITLE
add .clang-tidy, fix found bugs

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,0 +1,14 @@
+# Copy from OneFlow
+
+# `-allow-enabling-analyzer-alpha-checkers` should be passed to clang-tidy for CSA checkers named `clang-analyzer-alpha.*` (or `-allow-enabling-alpha-checkers` for run-clang-tidy.py)
+# `aggressive-binary-operation-simplification` should be enabled (via `-Xclang -analyzer-config -Xclang aggressive-binary-operation-simplification=true` in clang)
+# there is some problem in `clang-analyzer-alpha.clone.*`, so do not enable it
+# `clang-analyzer-alpha.deadcode.*` is just too verbose to enable
+Checks: '-*, maybe-*, clang-analyzer-core.*, clang-analyzer-unix.*, clang-analyzer-cplusplus.*, clang-analyzer-nullability.*, clang-analyzer-deadcode.*, clang-analyzer-security.*, clang-analyzer-optin.cplusplus.*, clang-analyzer-optin.performance.*, clang-analyzer-alpha.core.*, clang-analyzer-alpha.cplusplus.*, clang-analyzer-alpha.security.*, cppcoreguidelines-avoid-goto, cppcoreguidelines-interfaces-global-init, cppcoreguidelines-no-malloc, cppcoreguidelines-prefer-member-initializer, cppcoreguidelines-pro-type-member-init, cppcoreguidelines-pro-type-static-cast-downcast, cppcoreguidelines-slicing, cppcoreguidelines-special-member-functions, performance-unnecessary-value-param, performance-unnecessary-copy-initialization, performance-noexcept-move-constructor, performance-no-automatic-move, performance-move-const-arg, performance-implicit-conversion-in-loop, performance-for-range-copy, google-default-arguments, google-global-names-in-headers, google-explicit-constructor'
+
+CheckOptions:
+  # `cppcoreguidelines-special-member-functions` is enabled, refer to https://en.cppreference.com/w/cpp/language/rule_of_three
+  - key:             cppcoreguidelines-special-member-functions.AllowSoleDefaultDtor
+    value:           True
+  - key:             performance-move-const-arg.CheckTriviallyCopyableMove
+    value:           False

--- a/.gitignore
+++ b/.gitignore
@@ -53,3 +53,7 @@ build*/
 
 # 3rd
 3rdparty
+
+# Python
+*.egg-info/
+__pycache__/

--- a/examples/common/tengine_operations.c
+++ b/examples/common/tengine_operations.c
@@ -21,6 +21,7 @@
  * Copyright (c) 2020, OPEN AI LAB
  */
 
+#include <assert.h>
 #include <stdint.h>
 #include <math.h>
 #include <string.h>
@@ -479,7 +480,7 @@ image copyMaker(image im, int top, int bottom, int left, int right, float value)
 void save_image(image im, const char* name)
 {
     char buff[256] = {0};
-    unsigned char* data = (unsigned char*)calloc((size_t)im.w * im.h * im.c, sizeof(char));
+    unsigned char* data = (unsigned char*)calloc((size_t)im.w * im.h * im.c, sizeof(unsigned char));
     int i, k;
     for (k = 0; k < im.c; ++k)
     {
@@ -1019,6 +1020,7 @@ static void sort_cls_score(cls_score* array, int left, int right)
 
 void print_topk(float* data, int total_num, int topk)
 {
+    assert(total_num >= topk);
     cls_score* cls_scores = (cls_score*)malloc(total_num * sizeof(cls_score));
     for (int i = 0; i < total_num; i++)
     {

--- a/examples/tm_classification.c
+++ b/examples/tm_classification.c
@@ -71,6 +71,9 @@ int tengine_classify(const char* model_file, const char* image_file, int img_h, 
     int img_size = img_h * img_w * 3;
     int dims[] = {1, 3, img_h, img_w}; // nchw
     float* input_data = (float*)malloc(img_size * sizeof(float));
+    if (input_data == NULL) {
+        return -1;
+    }
 
     tensor_t input_tensor = get_graph_input_tensor(graph, 0, 0);
     if (input_tensor == NULL)

--- a/examples/tm_classification.c
+++ b/examples/tm_classification.c
@@ -71,7 +71,8 @@ int tengine_classify(const char* model_file, const char* image_file, int img_h, 
     int img_size = img_h * img_w * 3;
     int dims[] = {1, 3, img_h, img_w}; // nchw
     float* input_data = (float*)malloc(img_size * sizeof(float));
-    if (input_data == NULL) {
+    if (input_data == NULL)
+    {
         return -1;
     }
 

--- a/examples/tm_classification_uint8.c
+++ b/examples/tm_classification_uint8.c
@@ -91,7 +91,8 @@ int tengine_classify(const char* model_file, const char* image_file, int img_h, 
     int img_size = img_h * img_w * 3;
     int dims[] = {1, 3, img_h, img_w}; // nchw
     uint8_t* input_data = (uint8_t*)malloc(img_size);
-    if (input_data == NULL) {
+    if (input_data == NULL)
+    {
         return -1;
     }
 

--- a/examples/tm_classification_uint8.c
+++ b/examples/tm_classification_uint8.c
@@ -91,6 +91,9 @@ int tengine_classify(const char* model_file, const char* image_file, int img_h, 
     int img_size = img_h * img_w * 3;
     int dims[] = {1, 3, img_h, img_w}; // nchw
     uint8_t* input_data = (uint8_t*)malloc(img_size);
+    if (input_data == NULL) {
+        return -1;
+    }
 
     tensor_t input_tensor = get_graph_input_tensor(graph, 0, 0);
     if (input_tensor == NULL)

--- a/examples/tm_mobilefacenet.cpp
+++ b/examples/tm_mobilefacenet.cpp
@@ -70,7 +70,6 @@ int getFeature(const char* imagefile, float* feature)
     int height = MOBILE_FACE_HEIGHT;
     int width = MOBILE_FACE_WIDTH;
     int img_size = height * width * 3;
-    int dims[] = {1, 3, height, width};
     float means[3] = {DEFAULT_MEAN1, DEFAULT_MEAN2, DEFAULT_MEAN3};
     float scales[3] = {1, 1, 1};
     std::vector<float> input_data(img_size);

--- a/pytengine/setup.py
+++ b/pytengine/setup.py
@@ -22,19 +22,6 @@ src = father_path + "/build/install/lib/" + libtengine
 dst = dest + "/tengine/" + libtengine
 shutil.copyfile(src, dst)
 
-files = [
-    "__init__",
-    "base",
-    "context",
-    "device",
-    "graph",
-    "libinfo",
-    "node",
-    "tengine",
-    "tensor",
-    libtengine,
-]
-
 setup(
     name="pytengine",
     version="0.9.1",

--- a/source/device/cpu/op/reverse/reverse_ref.c
+++ b/source/device/cpu/op/reverse/reverse_ref.c
@@ -33,6 +33,7 @@
 #include "device/cpu/cpu_module.h"
 
 #include <math.h>
+#include <assert.h>
 
 struct reverse_param
 {
@@ -47,12 +48,12 @@ int ref_reverse_fp32(void* input, void* input_axis, void* output, const struct r
     int* axis_ptr = (int*)input_axis;
     int axis = axis_ptr[0];
 
-    int in_w = param->in_shape[3];
-    int in_hw = param->in_shape[2] * in_w;
-    int in_chw = param->in_shape[1] * in_hw;
-
     if (param->dim_size == 4)
     {
+        int in_w = param->in_shape[3];
+        int in_hw = param->in_shape[2] * in_w;
+        int in_chw = param->in_shape[1] * in_hw;
+
         if (axis == 0 || axis == -4)
         {
             for (int i = 0; i < param->in_shape[0]; i++)
@@ -136,12 +137,12 @@ int ref_reverse_uint8(void* input, void* input_axis, void* output, const struct 
     int* axis_ptr = (int*)input_axis;
     int axis = axis_ptr[0];
 
-    int in_w = param->in_shape[3];
-    int in_hw = param->in_shape[2] * in_w;
-    int in_chw = param->in_shape[1] * in_hw;
-
     if (param->dim_size == 4)
     {
+        int in_w = param->in_shape[3];
+        int in_hw = param->in_shape[2] * in_w;
+        int in_chw = param->in_shape[1] * in_hw;
+
         if (axis == 0 || axis == -4)
         {
             for (int i = 0; i < param->in_shape[0]; i++)

--- a/source/olreport/onlinereportutil.c
+++ b/source/olreport/onlinereportutil.c
@@ -168,9 +168,12 @@ void get_os_kernel_info(char* os, int maxlen)
         return;
     }
 
-    int offset = fscanf(fp, "%s", os);
+    int res = fscanf(fp, "%s", os);
+    if (res != 1) {
+        return;
+    }
     fclose(fp);
-    offset = strlen(os);
+    int offset = strlen(os);
     os[offset] = ' ';
     offset += 1;
 

--- a/source/olreport/onlinereportutil.c
+++ b/source/olreport/onlinereportutil.c
@@ -169,7 +169,8 @@ void get_os_kernel_info(char* os, int maxlen)
     }
 
     int res = fscanf(fp, "%s", os);
-    if (res != 1) {
+    if (res != 1)
+    {
         return;
     }
     fclose(fp);

--- a/source/utility/float.c
+++ b/source/utility/float.c
@@ -23,6 +23,7 @@
  */
 
 #include "utility/float.h"
+#include <math.h>
 
 #define BF16_EXP_MAX (256 - 1)  //  2^8 - 1
 #define FP16_EXP_MAX (32 - 1)   //  2^5 - 1
@@ -99,7 +100,7 @@ fp32_t fp16_to_fp32(fp16_t package)
         return data.value;
     }
 
-    return data.value;
+    return NAN;
 }
 
 fp16_t fp32_to_fp16(fp32_t value)

--- a/tools/convert_tool/caffe/caffe2tengine.cpp
+++ b/tools/convert_tool/caffe/caffe2tengine.cpp
@@ -24,6 +24,8 @@
 
 #include "caffe2tengine.hpp"
 
+#include <assert.h>
+
 /*
 *   SELF DEFINE VARIABLE
 *   FOR CAFFE SERIALIZER
@@ -149,7 +151,10 @@ static void load_blob(ir_graph_t* ir_graph, std::string node_name, const std::ve
                 }
             }
         }
-        set_ir_tensor_shape(ir_tensor, dims, dim_num);
+        int res = set_ir_tensor_shape(ir_tensor, dims, dim_num);
+        free(dims);
+        dims = nullptr;
+        assert(res == 0);
         ir_tensor->tensor_type = TENSOR_TYPE_CONST;
         int tensor_size = data_num * sizeof(float);
         ir_tensor->data = sys_malloc(tensor_size);

--- a/tools/convert_tool/onnx/onnx2tengine.cpp
+++ b/tools/convert_tool/onnx/onnx2tengine.cpp
@@ -208,7 +208,7 @@ int onnx_serializer::load_constant_tensor(ir_graph_t* graph, const onnx::GraphPr
 
             const char* name = node.input(1).c_str();
             int dim_num = onnx_tensor.dims_size();
-            int* dims = new int[dim_num];
+            std::vector<int> dims(dim_num);
             for (int j = 0; j < dim_num; j++)
             {
                 dims[j] = onnx_tensor.dims(j);
@@ -221,7 +221,7 @@ int onnx_serializer::load_constant_tensor(ir_graph_t* graph, const onnx::GraphPr
                 fprintf(stderr, "create ir tensor failed!\n");
                 return -1;
             }
-            set_ir_tensor_shape(ir_tensor, dims, dim_num);
+            set_ir_tensor_shape(ir_tensor, dims.data(), dim_num);
             ir_tensor->tensor_type = TENSOR_TYPE_CONST;
             // set tensor data
             if (7 == onnx_tensor.data_type())

--- a/tools/convert_tool/tensorflow/tf2tengine.cpp
+++ b/tools/convert_tool/tensorflow/tf2tengine.cpp
@@ -724,8 +724,8 @@ void tensorflow_serializer::CleanupResizeNearestNeighbor()
 
             for (unsigned int i = 0; i < data_node->outputs.size(); i++)
             {
-
-                if (data_node->outputs[i]->op == "Shape") {
+                if (data_node->outputs[i]->op == "Shape")
+                {
                     data_shape_node = data_node->outputs[i];
                 }
             }

--- a/tools/convert_tool/tensorflow/tf2tengine.cpp
+++ b/tools/convert_tool/tensorflow/tf2tengine.cpp
@@ -724,12 +724,13 @@ void tensorflow_serializer::CleanupResizeNearestNeighbor()
 
             for (unsigned int i = 0; i < data_node->outputs.size(); i++)
             {
-                data_shape_node = data_node->outputs[i];
 
-                if (data_shape_node->op == "Shape")
-                    break;
+                if (data_node->outputs[i]->op == "Shape") {
+                    data_shape_node = data_node->outputs[i];
+                }
             }
 
+            assert(data_shape_node != nullptr);
             DisconnectNode(data_shape_node);
 
             TFNode* mul_node = cur_node->inputs[1];

--- a/tools/convert_tool/utils/graph_optimizer/graph_opt.cpp
+++ b/tools/convert_tool/utils/graph_optimizer/graph_opt.cpp
@@ -413,8 +413,8 @@ static int weight_bn(ir_graph_t* graph, ir_node_t* conv_node, float* mean, float
     float* kernel_data = (float*)kernel_tensor->data;
     int channel_num = kernel_tensor->dims[0];
 
-    float* scale_mean = (float*)malloc(channel_num * sizeof(float));
-    float* scale_var_inv = (float*)malloc(channel_num * sizeof(float));
+    std::vector<float> scale_mean(channel_num);
+    std::vector<float> scale_var_inv(channel_num);
 
     float rescale_factor_tmp = rescale_factor;
     float* bias = NULL;
@@ -501,9 +501,6 @@ static int weight_bn(ir_graph_t* graph, ir_node_t* conv_node, float* mean, float
     {
         bias_data[i] = scale_mean[i];
     }
-
-    free(scale_var_inv);
-    free(scale_mean);
 
     return 0;
 }


### PR DESCRIPTION
添加 .clang-tidy，修复了 clang-tidy 发现的一部分容易修的问题，包含忘记 free、使用了未初始化的值、内存越界访问