### PR TITLE
[fix] fix typo

### DIFF
--- a/benchmark/README.md
+++ b/benchmark/README.md
@@ -15,7 +15,7 @@ Benchmark 是评估目标硬件平台网络模型运行速度的简单途径，�
 2. 将原始框架模型转换为 tmfile benchmark 专用模型，以 Caffe 框架的 mobilenet_v1 举例：
 
    ```shell
-   $ ./comvert_tm_tool -f caffe -p mobilenet_v1.prototxt -m mobilenet_v1.caffemodel -o mobilenet_v1_benchmark.tmfile
+   $ ./convert_tm_tool -f caffe -p mobilenet_v1.prototxt -m mobilenet_v1.caffemodel -o mobilenet_v1_benchmark.tmfile
    ```
 
    我们已经提前转换了一小部分评估模型在 [benchmark/models](benchmark/models) 中。

--- a/doc/docs_en/benchmark/benchmark_tools.md
+++ b/doc/docs_en/benchmark/benchmark_tools.md
@@ -15,7 +15,7 @@ $ export TM_FOR_BENCHMARK=1
 - Convert the original framework model to a dedicated tmfile benchmark model, using mobilenet_v1 of the Caffe framework as an example:
 
 ```
-$ ./comvert_tm_tool -f caffe -p mobilenet_v1.prototxt -m mobilenet_v1.caffemodel -o mobilenet_v1_benchmark.tmfile
+$ ./convert_tm_tool -f caffe -p mobilenet_v1.prototxt -m mobilenet_v1.caffemodel -o mobilenet_v1_benchmark.tmfile
 ```
 
 We have already converted a small part of the evaluation models in benchmark/models in advance.

--- a/doc/docs_zh/benchmark/benchmark_tools.md
+++ b/doc/docs_zh/benchmark/benchmark_tools.md
@@ -15,7 +15,7 @@ $ export TM_FOR_BENCHMARK=1
 - 将原始框架模型转换为 tmfile benchmark 专用模型，以 Caffe 框架的 mobilenet_v1 举例：
 
 ```
-$ ./comvert_tm_tool -f caffe -p mobilenet_v1.prototxt -m mobilenet_v1.caffemodel -o mobilenet_v1_benchmark.tmfile
+$ ./convert_tm_tool -f caffe -p mobilenet_v1.prototxt -m mobilenet_v1.caffemodel -o mobilenet_v1_benchmark.tmfile
 ```
 
 我们已经提前转换了一小部分评估模型在 benchmark/models 中。

--- a/doc/docs_zh/user_guides/visual_tool.md
+++ b/doc/docs_zh/user_guides/visual_tool.md
@@ -46,7 +46,7 @@ type: 数据类型，此处为 FP32 格式；维度信息，此模型为 [10,3,2
 
 a)  prob:
 
-name: 输出 tenso r的名称，如此处为 prob; 
+name: 输出 tensor 的名称，如此处为 prob; 
 type: 数据类型，此处为 FP32 格式；维度信息位置，须经过 infershape 后由 Tengine 计算得到输出尺寸。
 
 ##  模型绘图

--- a/examples/README.md
+++ b/examples/README.md
@@ -241,7 +241,7 @@ image file : images/carvana01.jpg
 img_h, img_w, scale[3], mean[3] : 512 512 , 0.004 0.004 0.004, 0.0 0.0 0.0
 Repeat 1 times, thread 1, avg time 4861.93 ms, max_time 4861.93 ms, min_time 4861.93 ms
 --------------------------------------
-segmentatation result is save as unet_out.png
+segmentation result is save as unet_out.png
 ```
 
 ![](https://z3.ax1x.com/2021/07/01/Rs8YjI.png)

--- a/examples/README_EN.md
+++ b/examples/README_EN.md
@@ -246,7 +246,7 @@ image file : images/carvana01.jpg
 img_h, img_w, scale[3], mean[3] : 512 512 , 0.004 0.004 0.004, 0.0 0.0 0.0
 Repeat 1 times, thread 1, avg time 4861.93 ms, max_time 4861.93 ms, min_time 4861.93 ms
 --------------------------------------
-segmentatation result is save as unet_out.png
+segmentation result is save as unet_out.png
 ```
 
 ![](https://z3.ax1x.com/2021/07/01/Rs8YjI.png)

--- a/examples/common/tengine_operations.h
+++ b/examples/common/tengine_operations.h
@@ -84,7 +84,7 @@ image make_image(int w, int h, int c);
 image make_empty_image(int w, int h, int c);
 
 /**
- * return ture if file exist
+ * return true if file exist
  * @param [in] file_name: file name
  * @return 1: success, 0: fail.
  */
@@ -223,7 +223,7 @@ image tranpose(image src);
 void draw_circle(image im, int x, int y, int radius, int r, int g, int b);
 
 /**
- *  do subtract between two image (image a and imge b)
+ *  do subtract between two image (image a and image b)
  * @param [in] a: input image
  * @param [in] b: input image
  * @param [out] c: output image

--- a/examples/tm_efficientdet_uint8.c
+++ b/examples/tm_efficientdet_uint8.c
@@ -506,7 +506,7 @@ int tengine_detect(const char* model_file, const char* image_file, int img_h, in
     free(anchors_y0);
     free(anchors_y1);
 
-    // filter boxes wiht confidence threshold
+    // filter boxes with confidence threshold
     Box_t* proposals_over_threshold = malloc(sizeof(Box_t) * num_proposals_over_threshold);
     int proposals_over_threshold_idx = 0;
     for (int i = 0; i < num_anchors; i++)

--- a/examples/tm_mobilefacenet.cpp
+++ b/examples/tm_mobilefacenet.cpp
@@ -88,7 +88,7 @@ int getFeature(const char* imagefile, float* feature)
     return outsize;
 }
 
-void normlize(float* feature, int size)
+void normalize(float* feature, int size)
 {
     float norm = 0;
     for (int i = 0; i < size; ++i)
@@ -167,8 +167,8 @@ int main(int argc, char* argv[])
         fprintf(stderr, "getFeature feature out len error");
     }
 
-    normlize(featurea.data(), feature_len);
-    normlize(featureb.data(), feature_len);
+    normalize(featurea.data(), feature_len);
+    normalize(featureb.data(), feature_len);
 
     float sim = 0;
     for (int i = 0; i < feature_len; ++i)

--- a/examples/tm_mobilefacenet_uint8.cpp
+++ b/examples/tm_mobilefacenet_uint8.cpp
@@ -136,7 +136,7 @@ int getFeature(const char* imagefile, float* feature)
     return output_size;
 }
 
-void normlize(float* feature, int size)
+void normalize(float* feature, int size)
 {
     float norm = 0;
     for (int i = 0; i < size; ++i)
@@ -215,8 +215,8 @@ int main(int argc, char* argv[])
         fprintf(stderr, "getFeature feature out len error");
     }
 
-    normlize(featurea.data(), feature_len);
-    normlize(featureb.data(), feature_len);
+    normalize(featurea.data(), feature_len);
+    normalize(featureb.data(), feature_len);
 
     float sim = 0;
     for (int i = 0; i < feature_len; ++i)

--- a/examples/tm_openpose.cpp
+++ b/examples/tm_openpose.cpp
@@ -66,15 +66,15 @@ void post_process_pose(cv::Mat img, cv::Mat frameCopy, float threshold, float* o
     for (int n = 0; n < num; n++)
     {
         cv::Point maxloc;
-        int piexlNums = H * W;
+        int pixelNums = H * W;
         double prob = -1;
-        for (int piexl = 0; piexl < piexlNums; ++piexl)
+        for (int pixel = 0; pixel < pixelNums; ++pixel)
         {
-            if (outdata[piexl] > prob)
+            if (outdata[pixel] > prob)
             {
-                prob = outdata[piexl];
-                maxloc.y = (int)piexl / H;
-                maxloc.x = (int)piexl % W;
+                prob = outdata[pixel];
+                maxloc.y = (int)pixel / H;
+                maxloc.x = (int)pixel % W;
             }
         }
         cv::Point2f p(-1, -1);
@@ -90,7 +90,7 @@ void post_process_pose(cv::Mat img, cv::Mat frameCopy, float threshold, float* o
         }
         points[n] = p;
         std::cout << n << ":" << p << std::endl;
-        outdata += piexlNums;
+        outdata += pixelNums;
     }
 
     int nPairs = sizeof(POSE_PAIRS) / sizeof(POSE_PAIRS[0]);

--- a/examples/tm_yolov5.cpp
+++ b/examples/tm_yolov5.cpp
@@ -406,7 +406,7 @@ int main(int argc, char* argv[])
     image img = imread(image_file);
     int output_node_num = get_graph_output_node_number(graph);
 
-    /* save detection reslult */
+    /* save detection result */
     std::vector<detection> detections;
 
     /* decode layer one by one*/


### PR DESCRIPTION
[路径]
[行号] [修改前] -> [修改后]

benchmark/readme.md 
18: comvert_tm_tool -> convert_tm_tool

doc/docs_en/benchmark/benchmark_tools.md
18: comvert_tm_tool -> convert_tm_tool

doc/docs_zh/benchmark/benchmark_tools.md
18: comvert_tm_tool -> convert_tm_tool

doc/docs_zh/user_guide/visual_tool.md
47: tenso r -> tensor

examples/common/tengine_operations.h
87: ture -> true
226: imge -> image

examples/readme_en.md
249: segmentatation -> segmentation

examples/readme.md
244: segmentatation -> segmentation

example/tm_efficientdet_uint8.c
509: wiht -> with

example/tm_mobilefacenet_uint8.cpp
139/218/219: normlize -> normalize

example/tm_mobilefacenet.cpp
91/170/171: normlize -> normalize

example/tm_openpose.cpp
69/71/73/75/76/77/93: piexl -> pixel

example/tm_yolov5.cpp
409: reslult -> result