### PR TITLE
修复onnx2tengine中对upsample的支持问题

### DIFF
--- a/tools/convert_tool/onnx/onnx2tengine.cpp
+++ b/tools/convert_tool/onnx/onnx2tengine.cpp
@@ -371,6 +371,29 @@ int onnx_serializer::load_constant_tensor(ir_graph_t* graph, const onnx::GraphPr
                     }
                 }
             }
+            else if(tensor_data_type == TENGINE_DT_FP32)
+            {
+                // to support float type constant data loading
+                int tensor_size = ir_tensor->elem_num * sizeof(float_t);
+                ir_tensor->data = sys_malloc(tensor_size);
+                float_t* mem_buf = (float_t*)ir_tensor->data;
+                if (onnx_tensor.has_raw_data())
+                {
+                    float_t* raw_data = (float_t*)onnx_tensor.raw_data().data();
+                    for (int j = 0; j < ir_tensor->elem_num; j++)
+                    {
+                        mem_buf[j] = raw_data[j];
+                    }
+                }
+                else
+                {
+                    int32_t* raw_data = (int32_t*)onnx_tensor.int32_data().data();
+                    for (int j = 0; j < ir_tensor->elem_num; j++)
+                    {
+                        mem_buf[j] = raw_data[j];
+                    }
+                }
+            }
             else
             {
                 int tensor_size = ir_tensor->elem_num * sizeof(uint8_t);

--- a/tools/convert_tool/onnx/onnx2tengine.cpp
+++ b/tools/convert_tool/onnx/onnx2tengine.cpp
@@ -318,7 +318,7 @@ int onnx_serializer::load_constant_tensor(ir_graph_t* graph, const onnx::GraphPr
 
         const std::string& op = node.op_type();
 
-        if ((op == "Reshape" || op == "Gather" || op == "Div" || op == "Resize"))
+        if ((op == "Reshape" || op == "Gather" || op == "Div" || op == "Resize" || op == "Upsample"))
         {
             if (node_tensor.count(node.input(1)) == 0)
                 continue;


### PR DESCRIPTION
在`load_constant_tensor`函数中有一处判断忽略了`Upsample`，导致`Upsample`的constant tensor输入被忽略，使得带有`Upsample`算子的onnx graph转换成不正确的tengine ir graph，并最终会在`load_graph_node`函数第643行附近导致segmentation fault。

https://github.com/OAID/Tengine/blob/739fd00f4721176bd30c56d0b42a6ade30ef4495/tools/convert_tool/onnx/onnx2tengine.cpp#L643