### PR TITLE
fix some bugs for DFQ quantize

### DIFF
--- a/tools/quantize/algorithm/quant_dfq.cpp
+++ b/tools/quantize/algorithm/quant_dfq.cpp
@@ -57,8 +57,9 @@ int QuantTool::data_free_quant()
     }
 
     struct graph* graphn = (struct graph*)graph;
-    struct node_graph* node_proto = (struct node_graph*)sys_malloc(sizeof(struct node_graph) * graphn->node_num);
-
+    // struct node_graph* node_proto = (struct node_graph*)sys_malloc(sizeof(struct node_graph) * graphn->node_num);  // crash access node_proto.input_node_list
+    std::vector<node_graph> node_proto(graphn->node_num);
+    
     for (int i = 0; i < graphn->node_num; i++)
     {
         struct node* n = graphn->node_list[i]; //ir node
@@ -246,16 +247,22 @@ int QuantTool::data_free_quant()
                             //////////////////////////////////////////////////////////////////////////////////
 
                             // layer ops sqrt
-                            float ops_range[dims1];
+                            // float ops_range[dims1];  // dims1 should be constant
+                            float* ops_range = new float[dims1];
                             for (int ops = 0; ops < dims1; ops++)
                             {
                                 ops_range[ops] = pow(layer0_range[ops] * layer1_range[ops] * layer2_range[ops], 1.0 / 3);
                             }
 
-                            float S01[dims1];
-                            float S01_F[dims1];
-                            float S12[dims1];
-                            float S12_F[dims1];
+                            // float S01[dims1];
+                            // float S01_F[dims1];
+                            // float S12[dims1];
+                            // float S12_F[dims1];
+                            float* S01 = new float[dims1];
+                            float* S01_F = new float[dims1];
+                            float* S12 = new float[dims1];
+                            float* S12_F = new float[dims1];   
+                            
                             for (int ops = 0; ops < dims1; ops++)
                             {
                                 if (ops_range[ops] == 0)
@@ -336,6 +343,16 @@ int QuantTool::data_free_quant()
                                     }
                                 }
                             }
+                            delete[] S01;     // free the memory
+                            S01 = NULL;
+                            delete[] S01_F;
+                            S01_F = NULL;
+                            delete[] S12;
+                            S12 = NULL;
+                            delete[] S12_F;
+                            S12_F = NULL;
+                            delete[] ops_range;
+                            ops_range = NULL;
                         }
                     }
                 }
@@ -424,14 +441,18 @@ int QuantTool::data_free_quant()
                                         //////////////////////////////////////////////////////////////////////////////////
 
                                         // layer ops sqrt
-                                        float ops_range[dims1];
+                                        // float ops_range[dims1];   // dims1 should be constant
+                                        float* ops_range = new float[dims1];
                                         for (int ops = 0; ops < dims1; ops++)
                                         {
                                             ops_range[ops] = sqrt(layer0_range[ops] * layer1_range[ops]);
                                         }
 
-                                        float S01[dims1];
-                                        float S01_F[dims1];
+                                        // float S01[dims1];
+                                        // float S01_F[dims1];
+                                        float* S01 = new float[dims1];
+                                        float* S01_F = new float[dims1];
+                                        
                                         for (int ops = 0; ops < dims1; ops++)
                                         {
                                             if (ops_range[ops] == 0)
@@ -485,6 +506,12 @@ int QuantTool::data_free_quant()
                                                 }
                                             }
                                         }
+                                        delete[] S01;    // free the memory
+                                        S01 = NULL;
+                                        delete[] S01_F;
+                                        S01_F = NULL;
+                                        delete[] ops_range;
+                                        ops_range = NULL;
                                     }
                                 }
                             }


### PR DESCRIPTION
fix some bugs for DFQ quantize：
（1）fix crash access node_proto.input_node_list，use `std::vector<node_graph> node_proto(graphn->node_num)` to replace `sys_malloc` when declare `node_proto`,
（2）fix declare `float ops_range[dims1]` crash，dims1 should be constant，use `float* ops_range = new float[dims1]` to repace.