### PR TITLE
Update trt_define.h

### DIFF
--- a/source/device/tensorrt/trt_define.h
+++ b/source/device/tensorrt/trt_define.h
@@ -24,6 +24,9 @@
 
 #pragma once
 
+#include <iostream>
+#include <string>
+
 #define TRT_DEVICE_NAME "TensorRT"
 
 #define EXPORT_BEGIN  extern "C" {

--- a/source/device/tensorrt/trt_executor.cc
+++ b/source/device/tensorrt/trt_executor.cc
@@ -84,7 +84,7 @@ TensorRTEngine::TensorRTEngine()
 
     this->precision = nvinfer1::DataType::kFLOAT;
 
-    this->option.dev_name = TRT_DEVICE_NAME;
+    this->option.dev_name = (char *)TRT_DEVICE_NAME;
     this->option.precision = TENGINE_DT_FP32;
     this->option.gpu_index = 0;
     this->option.dla_index = -1;


### PR DESCRIPTION
(1) add `#include <iostream>` to fix the bug `"string" is not a member of "std"`;
(2) add `#include <string>` to fix the bug `"to_string" is not  member of "std"`;