### PR TITLE
fix missing 'fprintf' 'stderr' problem

### DIFF
--- a/source/device/cuda/cuda_executor.hpp
+++ b/source/device/cuda/cuda_executor.hpp
@@ -27,6 +27,7 @@
 #include <map>
 #include <vector>
 #include <functional>
+#include <cstdio>
 
 extern "C" {
 #include "graph/node.h"


### PR DESCRIPTION
Patch for Linux with GCC 11.1.0 and CUDA V11.5.119