### PR TITLE
fix TENGINE_DUMP_DIR might not be treated as dir name

### DIFF
--- a/source/device/cpu/cpu_dump.c
+++ b/source/device/cpu/cpu_dump.c
@@ -533,11 +533,11 @@ void extract_feature_from_tensor(const char* comment, const char* layer_name, co
 
     const char* env_path = getenv(TENGINE_DUMP_DIR);
 
-    if (NULL != env_path && (256 - 2) > strlen(env_path))
+    if (NULL != env_path && '\0' != env_path[0] && (256 - 2) > strlen(env_path))
     {
         strcpy(save_dir, env_path);
 
-        if ('/' == save_dir[strlen(env_path)] || '\\' == save_dir[strlen(env_path)])
+        if ('/' == save_dir[strlen(env_path) - 1] || '\\' == save_dir[strlen(env_path) - 1])
         {
 #ifdef _MSC_VER
             save_dir[strlen(env_path)] = '\\';

--- a/source/device/opendla/odla_dump.c
+++ b/source/device/opendla/odla_dump.c
@@ -518,11 +518,11 @@ void extract_feature_from_tensor_odla(const char* comment, const char* layer_nam
 
     const char* env_path = getenv(TENGINE_DUMP_DIR);
 
-    if (NULL != env_path && (256 - 2) > strlen(env_path))
+    if (NULL != env_path && '\0' != env_path[0] && (256 - 2) > strlen(env_path))
     {
         strcpy(save_dir, env_path);
 
-        if ('/' == save_dir[strlen(env_path)] || '\\' == save_dir[strlen(env_path)])
+        if ('/' == save_dir[strlen(env_path) - 1] || '\\' == save_dir[strlen(env_path) - 1])
         {
 #ifdef _MSC_VER
             save_dir[strlen(env_path)] = '\\';

--- a/source/device/tim-vx/timvx_dump.c
+++ b/source/device/tim-vx/timvx_dump.c
@@ -458,11 +458,11 @@ void extract_feature_from_tensor_timvx(const char* comment, const char* layer_na
 
     const char* env_path = getenv(TENGINE_DUMP_DIR);
 
-    if (NULL != env_path && (256 - 2) > strlen(env_path))
+    if (NULL != env_path && '\0' != env_path[0] && (256 - 2) > strlen(env_path))
     {
         strcpy(save_dir, env_path);
 
-        if ('/' == save_dir[strlen(env_path)] || '\\' == save_dir[strlen(env_path)])
+        if ('/' == save_dir[strlen(env_path)  - 1] || '\\' == save_dir[strlen(env_path) - 1])
         {
 #ifdef _MSC_VER
             save_dir[strlen(env_path)] = '\\';


### PR DESCRIPTION
The old code uses wrong index so it can never append `"/"` or `"\"` to `TENGINE_DUMP_DIR` when needed. This PR fixes it.