### PR TITLE
Fix wrong parameter orders like stride_w and stride_h of TIM-VX

### DIFF
--- a/source/device/tim-vx/op/timvx_convolution.cc
+++ b/source/device/tim-vx/op/timvx_convolution.cc
@@ -80,9 +80,9 @@ bool VXEngine::AddConvolutionNode(struct node* ir_node)
     {
         auto conv = this->graph->CreateOperation<tim::vx::ops::Conv2d>(
             weight_tensor->dims[0], tim::vx::PadType::AUTO,
-            std::array<uint32_t, 2>({ (unsigned int)param->kernel_h, (unsigned int)param->kernel_w }),
-            std::array<uint32_t, 2>({ (unsigned int)param->stride_h, (unsigned int)param->stride_w }),
-            std::array<uint32_t, 2>({ (unsigned int)param->dilation_h, (unsigned int)param->dilation_w }),
+            std::array<uint32_t, 2>({ (unsigned int)param->kernel_w, (unsigned int)param->kernel_h }),
+            std::array<uint32_t, 2>({ (unsigned int)param->stride_w, (unsigned int)param->stride_h }),
+            std::array<uint32_t, 2>({ (unsigned int)param->dilation_w, (unsigned int)param->dilation_h }),
             std::array<uint32_t, 4>({ (unsigned int)param->pad_w0, (unsigned int)param->pad_w1,
                                       (unsigned int)param->pad_h0, (unsigned int)param->pad_h1 }),
             multiplier);
@@ -151,8 +151,8 @@ bool VXEngine::AddConvolutionNode(struct node* ir_node)
         auto conv = this->graph->CreateOperation<tim::vx::ops::GroupedConv2d>(
             std::array<uint32_t, 4>({ (unsigned int)param->pad_w0, (unsigned int)param->pad_w1,
                                       (unsigned int)param->pad_h0, (unsigned int)param->pad_h1 }),
-            std::array<uint32_t, 2>({ (unsigned int)param->stride_h, (unsigned int)param->stride_w }),
-            std::array<uint32_t, 2>({ (unsigned int)param->dilation_h, (unsigned int)param->dilation_w }),
+            std::array<uint32_t, 2>({ (unsigned int)param->stride_w, (unsigned int)param->stride_h }),
+            std::array<uint32_t, 2>({ (unsigned int)param->dilation_w, (unsigned int)param->dilation_h }),
             param->group);
         if (param->activation >= 0)
         {

--- a/source/device/tim-vx/op/timvx_deconv.cc
+++ b/source/device/tim-vx/op/timvx_deconv.cc
@@ -74,11 +74,11 @@ bool VXEngine::AddDeconvNode(struct node* ir_node)
 
     auto deconv = this->graph->CreateOperation<tim::vx::ops::DeConv2d>(
             weight_tensor->dims[0], tim::vx::PadType::AUTO,
-            std::array<uint32_t, 2>({ (unsigned int)param->kernel_h, (unsigned int)param->kernel_w }),
-            std::array<uint32_t, 2>({ (unsigned int)param->stride_h, (unsigned int)param->stride_w }),
-            std::array<uint32_t, 2>({ (unsigned int)param->output_pad_h0, (unsigned int)param->output_pad_w0 }),
-            std::array<uint32_t, 4>({ (unsigned int)param->pad_h0, (unsigned int)param->pad_h1,
-                                      (unsigned int)param->pad_w0, (unsigned int)param->pad_w1 }),
+            std::array<uint32_t, 2>({ (unsigned int)param->kernel_w, (unsigned int)param->kernel_h }),
+            std::array<uint32_t, 2>({ (unsigned int)param->stride_w, (unsigned int)param->stride_h }),
+            std::array<uint32_t, 2>({ (unsigned int)param->output_pad_w0, (unsigned int)param->output_pad_h0 }),
+            std::array<uint32_t, 4>({ (unsigned int)param->pad_w0, (unsigned int)param->pad_w1,
+                                      (unsigned int)param->pad_h0, (unsigned int)param->pad_h1 }),
             (unsigned int)param->group  );
     
     vx_node_map[ir_node->index] = deconv;

--- a/source/device/tim-vx/op/timvx_pooling.cc
+++ b/source/device/tim-vx/op/timvx_pooling.cc
@@ -87,7 +87,7 @@ bool VXEngine::AddPoolingNode(struct node* ir_node)
 
     auto pool = graph->CreateOperation<tim::vx::ops::Pool2d>(
             pooltype,
-            std::array<uint32_t, 4>({ (unsigned int)param->pad_h0, (unsigned int)param->pad_h1, (unsigned int)param->pad_w0, (unsigned int)param->pad_w1}),
+            std::array<uint32_t, 4>({ (unsigned int)param->pad_w0, (unsigned int)param->pad_w1, (unsigned int)param->pad_h0, (unsigned int)param->pad_h1}),
             std::array<uint32_t, 2>({ (unsigned int)param->kernel_w, (unsigned int)param->kernel_h}),
             std::array<uint32_t, 2>({(unsigned int)param->stride_w, (unsigned int)param->stride_h}));
 


### PR DESCRIPTION
TIM-VX uses an order of `WHCN`, but some op constructor doesn't follow this rule. This PR can fix it.