### PR TITLE
fix(dump-tensors): correctly ensure TG_DEBUG_DUMP_DIR is a folder

### DIFF
--- a/source/device/cpu/cpu_dump.c
+++ b/source/device/cpu/cpu_dump.c
@@ -537,7 +537,7 @@ void extract_feature_from_tensor(const char* comment, const char* layer_name, co
     {
         strcpy(save_dir, env_path);
 
-        if ('/' == save_dir[strlen(env_path) - 1] || '\\' == save_dir[strlen(env_path) - 1])
+        if ('/' != save_dir[strlen(env_path) - 1] && '\\' != save_dir[strlen(env_path) - 1])
         {
 #ifdef _MSC_VER
             save_dir[strlen(env_path)] = '\\';

--- a/source/device/opendla/odla_dump.c
+++ b/source/device/opendla/odla_dump.c
@@ -522,7 +522,7 @@ void extract_feature_from_tensor_odla(const char* comment, const char* layer_nam
     {
         strcpy(save_dir, env_path);
 
-        if ('/' == save_dir[strlen(env_path) - 1] || '\\' == save_dir[strlen(env_path) - 1])
+        if ('/' != save_dir[strlen(env_path) - 1] && '\\' != save_dir[strlen(env_path) - 1])
         {
 #ifdef _MSC_VER
             save_dir[strlen(env_path)] = '\\';

--- a/source/device/tim-vx/timvx_dump.c
+++ b/source/device/tim-vx/timvx_dump.c
@@ -462,7 +462,7 @@ void extract_feature_from_tensor_timvx(const char* comment, const char* layer_na
     {
         strcpy(save_dir, env_path);
 
-        if ('/' == save_dir[strlen(env_path) - 1] || '\\' == save_dir[strlen(env_path) - 1])
+        if ('/' != save_dir[strlen(env_path) - 1] && '\\' != save_dir[strlen(env_path) - 1])
         {
 #ifdef _MSC_VER
             save_dir[strlen(env_path)] = '\\';


### PR DESCRIPTION
This is a complement of #1283 which uses wrong comparisons - the correct logic is to append a delimiter if only a last character **is not** a delimiter.