### PR TITLE
add support of negative axis value, e.g. -1, for cpu split operator

### DIFF
--- a/source/device/cpu/op/split/split_ref.c
+++ b/source/device/cpu/op/split/split_ref.c
@@ -163,6 +163,8 @@ static int run(struct node_ops* node_ops, struct exec_node* exec_node, struct ex
     /* the follow codes need to be checked ! */
     /* maybe int8 need dequant and quant */
     int slice_axis = split_param->axis;
+    if (slice_axis<0)
+        slice_axis = input_tensor->dim_num+slice_axis;
     int num_slices = 1;
     int slice_size = 1;
 

--- a/source/operator/prototype/split.c
+++ b/source/operator/prototype/split.c
@@ -39,7 +39,10 @@ static int infer_shape(ir_node_t* node)
     struct split_param* split_param = (struct split_param*)(node->op.param_mem);
 
     int axis = split_param->axis;
-
+    
+    if (axis<0)
+        axis=input->dim_num+axis;
+    
     int input_dim[4];
     for (int i = 0; i < input->dim_num; i++)
         input_dim[i] = input->dims[i];


### PR DESCRIPTION
onnx model support negative axis, e.g. -1 as split dim parameter, which means the last dimension and is straightforward for pyhton. The cpu split operator in this repo, in c/c++ code, would crash in such a case. I added support of axis -1 in this commit.