### PR TITLE
flatten.c correction related to output dims

### DIFF
--- a/source/operator/prototype/flatten.c
+++ b/source/operator/prototype/flatten.c
@@ -53,7 +53,9 @@ static int infer_shape(struct node* node)
 
     output->layout = TENGINE_LAYOUT_NHWC;
 
-    set_ir_tensor_shape(output, dims, 4);
+    //set_ir_tensor_shape(output, dims, 4);
+    //stephen@20220923
+    set_ir_tensor_shape(output, dims, 2);
 
     return 0;
 }


### PR DESCRIPTION
After flatten layer, the input dims 4 should be squeezed to 2. The original bug with output dims 4 is corrected.