### PR TITLE
acl_executor.cc fixed bug: scratch_mem invalid memory released condition

### DIFF
--- a/source/device/acl/acl_executor.cc
+++ b/source/device/acl/acl_executor.cc
@@ -603,7 +603,7 @@ int CLGraph::run(struct subgraph *subgraph)
         }
     }
 
-    if(!scratch_mem)
+    if(scratch_mem)
         sys_free(scratch_mem);
 
     int size = functions_map_.size();


### PR DESCRIPTION
This error resulted in memory leaks for ACL device type.