### PR TITLE
Fix mixed signed/unsigned comparisons and enforce size_t for object sizes in infer_shape

### DIFF
--- a/source/operator/prototype/generic.c
+++ b/source/operator/prototype/generic.c
@@ -41,8 +41,8 @@ static int infer_shape(struct node* node)
     struct generic_param* generic_param = (struct generic_param*)(node->op.param_mem);
 
     /* check input/output number */
-    int input_num = input->elem_num;
-    int output_num = output->elem_num;
+    size_t  input_num = input->elem_num;
+    size_t  output_num = output->elem_num;
 
     if (input_num > generic_param->max_input_num)
     {

--- a/source/operator/prototype/generic_param.h
+++ b/source/operator/prototype/generic_param.h
@@ -28,8 +28,8 @@
 struct generic_param
 {
     const char* op_name; // what real action?
-    int max_input_num;
-    int max_output_num;
+    size_t max_input_num;
+    size_t max_output_num;
 };
 
 #endif


### PR DESCRIPTION
In `infer_shape`, variables holding tensor element counts were declared as `int`/`uint32_t` and compared against fields from `generic_param`. This caused:

1. Mixed signed/unsigned comparisons → implicit conversions may lead to incorrect results.
2. Use of `int`/`uint32_t` for object sizes instead of the recommended `size_t`.

Importance

- May cause logical errors when values exceed INT_MAX.
- Potential risk of undefined behavior with very large tensors (>2G elements).

Related Standards:

- MISRA C++ Rule 5-0-4: "An implicit integral conversion shall not change the signedness"
- CERT C++ INT31-C: "Ensure that integer conversions do not result in lost or misinterpreted data"

Possible CWE Classification:
CWE-681: Incorrect Conversion between Numeric Types